### PR TITLE
feat: enable routing from aircraft

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -64,3 +64,4 @@ callsign
 nodetype
 oneshot
 ewkb
+callsigns

--- a/client-grpc/src/grpc.rs
+++ b/client-grpc/src/grpc.rs
@@ -167,10 +167,10 @@ pub struct PathSegment {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BestPathRequest {
-    /// Start Node (Vertiport or Aircraft)
+    /// Start Node - UUID for Vertiports, Callsigns for Aircraft
     #[prost(string, tag = "1")]
-    pub node_uuid_start: ::prost::alloc::string::String,
-    /// End Node (Vertiport)
+    pub node_start_id: ::prost::alloc::string::String,
+    /// End Node (Vertiport UUID)
     #[prost(string, tag = "2")]
     pub node_uuid_end: ::prost::alloc::string::String,
     /// Start Node Type (Vertiport or Aircraft Allowed)

--- a/client-grpc/src/service.rs
+++ b/client-grpc/src/service.rs
@@ -18,7 +18,7 @@ where
     /// The type expected for ReadyResponse structs.
     type ReadyResponse;
 
-    /// Returns a [`tonic::Response`] containing a [`ReadyResponse`]
+    /// Returns a [`tonic::Response`] containing a [`ReadyResponse`](Self::ReadyResponse)
     /// Takes an [`ReadyRequest`](Self::ReadyRequest).
     ///
     /// # Errors
@@ -29,7 +29,7 @@ where
     /// # Examples
     /// ```
     /// use lib_common::grpc::get_endpoint_from_env;
-    /// use svc_gis_client_grpc::client::{ReadyRequest, RpcServiceClient};
+    /// use svc_gis_client_grpc::client::{ReadyRequest, ReadyResponse, RpcServiceClient};
     /// use svc_gis_client_grpc::{Client, GrpcClient};
     /// use svc_gis_client_grpc::service::Client as ServiceClient;
     /// use tonic::transport::Channel;
@@ -195,7 +195,7 @@ where
     ///     let (host, port) = get_endpoint_from_env("SERVER_HOSTNAME", "SERVER_PORT_GRPC");
     ///     let connection = GrpcClient::<RpcServiceClient<Channel>>::new_client(&host, port, "gis");
     ///     let request = tonic::Request::new(BestPathRequest {
-    ///         node_uuid_start: "".to_string(),
+    ///         node_start_id: "".to_string(),
     ///         node_uuid_end: "".to_string(),
     ///         start_type: 0,
     ///         time_start: datetime_to_timestamp(&chrono::Utc::now()),

--- a/proto/grpc.proto
+++ b/proto/grpc.proto
@@ -167,10 +167,10 @@ message PathSegment {
 
 // Best Path Request object
 message BestPathRequest {
-    // Start Node (Vertiport or Aircraft)
-    string node_uuid_start = 1;
+    // Start Node - UUID for Vertiports, Callsigns for Aircraft
+    string node_start_id = 1;
 
-    // End Node (Vertiport)
+    // End Node (Vertiport UUID)
     string node_uuid_end = 2;
 
     // Start Node Type (Vertiport or Aircraft Allowed)

--- a/server/src/grpc/server.rs
+++ b/server/src/grpc/server.rs
@@ -119,12 +119,7 @@ impl RpcService for ServerImpl {
 
         let path_type = match num::FromPrimitive::from_i32(request.start_type) {
             Some(NodeType::Vertiport) => PathType::PortToPort,
-            Some(NodeType::Aircraft) => {
-                grpc_error!("(grpc best_path) attempt to route from aircraft.");
-                return Err(Status::unimplemented(
-                    "Aircraft to vertiport routing is not yet supported.",
-                ));
-            }
+            Some(NodeType::Aircraft) => PathType::AircraftToPort,
             _ => {
                 grpc_error!("(grpc best_path) invalid start node type.");
                 return Err(Status::invalid_argument(
@@ -291,12 +286,7 @@ impl RpcService for ServerImpl {
 
         let path_type = match num::FromPrimitive::from_i32(request.start_type) {
             Some(NodeType::Vertiport) => PathType::PortToPort,
-            Some(NodeType::Aircraft) => {
-                grpc_error!("(grpc best_path MOCK) attempt to route from aircraft.");
-                return Err(Status::unimplemented(
-                    "Aircraft to vertiport routing is not yet supported.",
-                ));
-            }
+            Some(NodeType::Aircraft) => PathType::AircraftToPort,
             _ => {
                 grpc_error!("(grpc best_path MOCK) invalid start node type.");
                 return Err(Status::invalid_argument(

--- a/server/src/postgis/nofly.rs
+++ b/server/src/postgis/nofly.rs
@@ -73,8 +73,12 @@ fn sanitize(req_zones: Vec<RequestNoFlyZone>) -> Result<Vec<GisNoFlyZone>, NoFly
 
     let mut zones: Vec<GisNoFlyZone> = vec![];
     for zone in req_zones {
-        if !super::utils::check_string(&zone.label, LABEL_REGEX, LABEL_MAX_LENGTH) {
-            postgis_error!("(sanitize nofly) Invalid no-fly zone label: {}", zone.label);
+        if let Err(e) = super::utils::check_string(&zone.label, LABEL_REGEX, LABEL_MAX_LENGTH) {
+            postgis_error!(
+                "(sanitize nofly) Invalid no-fly zone label: {}; {}",
+                zone.label,
+                e
+            );
             return Err(NoFlyZoneError::Label);
         }
 

--- a/server/src/postgis/vertiport.rs
+++ b/server/src/postgis/vertiport.rs
@@ -65,10 +65,11 @@ fn sanitize(vertiports: Vec<RequestVertiport>) -> Result<Vec<Vertiport>, Vertipo
 
         let label = match &vertiport.label {
             Some(label) => {
-                if !super::utils::check_string(label, LABEL_REGEX, LABEL_MAX_LENGTH) {
+                if let Err(e) = super::utils::check_string(label, LABEL_REGEX, LABEL_MAX_LENGTH) {
                     postgis_error!(
-                        "(sanitize vertiports) Vertiport {} has invalid label.",
-                        vertiport.uuid
+                        "(sanitize vertiports) Vertiport {} has invalid label: {}",
+                        vertiport.uuid,
+                        e
                     );
                     return Err(VertiportError::Label);
                 }

--- a/server/src/postgis/waypoint.rs
+++ b/server/src/postgis/waypoint.rs
@@ -49,10 +49,11 @@ fn sanitize(waypoints: Vec<RequestWaypoint>) -> Result<Vec<Waypoint>, WaypointEr
     }
 
     for waypoint in waypoints {
-        if !super::utils::check_string(&waypoint.label, LABEL_REGEX, LABEL_MAX_LENGTH) {
+        if let Err(e) = super::utils::check_string(&waypoint.label, LABEL_REGEX, LABEL_MAX_LENGTH) {
             postgis_error!(
-                "(sanitize waypoints) Invalid waypoint label: {}",
-                waypoint.label
+                "(sanitize waypoints) Invalid waypoint label: {}; {}",
+                waypoint.label,
+                e
             );
             return Err(WaypointError::Label);
         }


### PR DESCRIPTION
svc-scheduler should get paths from aircraft to pads for deadhead flights, so implementing this in R3