### PR TITLE
feat: add nearest neighbor request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,10 +1482,11 @@ dependencies = [
 
 [[package]]
 name = "postgres-derive"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "070ffaa78859c779b19f9358ce035480479cf2619e968593ffbe72abcb6e0fcf"
+checksum = "83145eba741b050ef981a9a1838c843fa7665e154383325aa8b440ae703180a2"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.27",
@@ -1524,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f028f05971fe20f512bcc679e2c10227e57809a3af86a7606304435bc8896cd6"
+checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
 dependencies = [
  "bytes",
  "chrono",
@@ -1612,6 +1613,8 @@ dependencies = [
  "prettyplease",
  "prost",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn 1.0.109",
  "tempfile",
@@ -1638,6 +1641,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+dependencies = [
+ "bitflags 1.3.2",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "10.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0194e6e1966c23cc5fd988714f85b18d548d773e81965413555d96569931833d"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -2034,6 +2057,7 @@ dependencies = [
  "log",
  "num-derive",
  "num-traits",
+ "postgres-types",
  "prost",
  "prost-types",
  "rand",
@@ -2438,6 +2462,15 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/client-grpc/Cargo.toml
+++ b/client-grpc/Cargo.toml
@@ -34,6 +34,7 @@ deadpool-postgres = { version = "0.10", optional = true }
 log               = { version = "0.4" }
 num-derive        = "0.3"
 num-traits        = "0.2"
+postgres-types    = "0.2"
 prost             = "0.11"
 prost-types       = "0.11"
 svc-gis           = { path = "../server", optional = true }
@@ -41,7 +42,6 @@ tokio-postgres    = { version = "0.7", optional = true }
 tonic             = "0.8"
 tower             = { version = "0.4", optional = true }
 uuid              = { version = "1.3", features = ["v4"] }
-
 
 [dependencies.lib-common]
 features = ["grpc"]

--- a/client-grpc/src/grpc.rs
+++ b/client-grpc/src/grpc.rs
@@ -234,7 +234,9 @@ pub struct NearestNeighborResponse {
     pub distances: ::prost::alloc::vec::Vec<DistanceTo>,
 }
 /// Types of nodes in itinerary
+#[derive(postgres_types::FromSql)]
 #[derive(num_derive::FromPrimitive)]
+#[postgres(name = "nodetype")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum NodeType {

--- a/client-grpc/src/grpc.rs
+++ b/client-grpc/src/grpc.rs
@@ -191,6 +191,48 @@ pub struct BestPathResponse {
     #[prost(message, repeated, tag = "1")]
     pub segments: ::prost::alloc::vec::Vec<PathSegment>,
 }
+/// Nearest Neighbor Request object
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NearestNeighborRequest {
+    /// Start Node - UUID for Vertiports, Callsigns for Aircraft
+    #[prost(string, tag = "1")]
+    pub start_node_id: ::prost::alloc::string::String,
+    /// Start Node Type (Vertiport or Aircraft Allowed)
+    #[prost(enumeration = "NodeType", tag = "2")]
+    pub start_type: i32,
+    /// End Node Type (Vertiport or Aircraft Allowed)
+    #[prost(enumeration = "NodeType", tag = "3")]
+    pub end_type: i32,
+    /// Limit to this many results
+    #[prost(int32, tag = "4")]
+    pub limit: i32,
+    /// Limit to this range
+    #[prost(float, tag = "5")]
+    pub max_range_meters: f32,
+}
+/// Distance to a node
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DistanceTo {
+    /// Vertiport or Aircraft ID
+    #[prost(string, tag = "1")]
+    pub label: ::prost::alloc::string::String,
+    /// Vertiport or Aircraft Type
+    #[prost(enumeration = "NodeType", tag = "2")]
+    pub target_type: i32,
+    /// Distance to vertiport
+    #[prost(float, tag = "3")]
+    pub distance_meters: f32,
+}
+/// Nearest Vertiports Request object
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NearestNeighborResponse {
+    /// Distances to nearby objects
+    #[prost(message, repeated, tag = "1")]
+    pub distances: ::prost::alloc::vec::Vec<DistanceTo>,
+}
 /// Types of nodes in itinerary
 #[derive(num_derive::FromPrimitive)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
@@ -404,6 +446,25 @@ pub mod rpc_service_client {
                 })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/grpc.RpcService/bestPath");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn nearest_neighbors(
+            &mut self,
+            request: impl tonic::IntoRequest<super::NearestNeighborRequest>,
+        ) -> Result<tonic::Response<super::NearestNeighborResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/grpc.RpcService/nearestNeighbors",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }

--- a/proto/grpc.proto
+++ b/proto/grpc.proto
@@ -13,6 +13,7 @@ service RpcService {
     rpc updateAircraftPosition(UpdateAircraftPositionRequest)
         returns (UpdateResponse);
     rpc bestPath(BestPathRequest) returns (BestPathResponse);
+    rpc nearestNeighbors(NearestNeighborRequest) returns (NearestNeighborResponse);
 }
 
 // Ready Request object
@@ -187,4 +188,41 @@ message BestPathRequest {
 message BestPathResponse {
     // Nodes in the best path
     repeated PathSegment segments = 1;
+}
+
+// Nearest Neighbor Request object
+message NearestNeighborRequest {
+    // Start Node - UUID for Vertiports, Callsigns for Aircraft
+    string start_node_id = 1;
+
+    // Start Node Type (Vertiport or Aircraft Allowed)
+    NodeType start_type = 2;
+
+    // End Node Type (Vertiport or Aircraft Allowed)
+    NodeType end_type = 3;
+
+    // Limit to this many results
+    int32 limit = 4;
+
+    // Limit to this range
+    float max_range_meters = 5;
+}
+
+// Distance to a node
+message DistanceTo {
+    // Vertiport or Aircraft ID
+    string label = 1;
+
+    // Vertiport or Aircraft Type
+    NodeType target_type = 2;
+
+    // Distance to vertiport
+    float distance_meters = 3;
+}
+
+// Nearest Vertiports Request object
+message NearestNeighborResponse {
+
+    // Distances to nearby objects
+    repeated DistanceTo distances = 1;
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -95,4 +95,4 @@ features         = ["user-hooks"]
 version          = "1"
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = { version = "0.8", features = ["cleanup-markdown"] }

--- a/server/build.rs
+++ b/server/build.rs
@@ -10,7 +10,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .type_attribute("ReadyResponse", "#[derive(Eq, Copy)]")
         .type_attribute("UpdateResponse", "#[derive(Eq, Copy)]")
         .type_attribute("PathSegment", "#[derive(Copy)]")
+        .type_attribute("NodeType", "#[derive(postgres_types::FromSql)]")
         .type_attribute("NodeType", "#[derive(num_derive::FromPrimitive)]")
+        .type_attribute("NodeType", r#"#[postgres(name = "nodetype")]"#)
         .type_attribute("Coordinates", "#[derive(Copy)]");
 
     let client_config = server_config.clone();

--- a/server/src/grpc/server.rs
+++ b/server/src/grpc/server.rs
@@ -155,7 +155,7 @@ impl RpcService for ServerImpl {
                 Ok(Response::new(response))
             }
             Err(e) => {
-                grpc_error!("(grpc nearest_neighbors) error getting best path.");
+                grpc_error!("(grpc nearest_neighbors) error getting nearest neighbors.");
                 Err(Status::internal(e.to_string()))
             }
         }

--- a/server/src/postgis/mod.rs
+++ b/server/src/postgis/mod.rs
@@ -11,9 +11,6 @@ pub mod utils;
 pub mod vertiport;
 pub mod waypoint;
 
-use crate::grpc::server::NodeType as GrpcNodeType;
-use postgres_types::FromSql;
-
 /// Routing can occur from a vertiport to a vertiport
 /// Or an aircraft to a vertiport (in-flight re-routing)
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -23,65 +20,4 @@ pub enum PathType {
 
     /// Route from an aircraft to a vertiport
     AircraftToPort = 1,
-}
-
-/// Types of nodes returned by the routing algorithm
-#[derive(Debug, Copy, Clone, FromSql, PartialEq)]
-#[postgres(name = "nodetype")]
-pub enum NodeType {
-    /// Vertiport Node
-    #[postgres(name = "vertiport")]
-    Vertiport,
-
-    /// Waypoint Node
-    #[postgres(name = "waypoint")]
-    Waypoint,
-
-    /// Aircraft Node
-    #[postgres(name = "aircraft")]
-    Aircraft,
-}
-
-impl TryFrom<i32> for NodeType {
-    type Error = ();
-    fn try_from(v: i32) -> Result<Self, Self::Error> {
-        match v {
-            x if x == NodeType::Vertiport as i32 => Ok(NodeType::Vertiport),
-            x if x == NodeType::Aircraft as i32 => Ok(NodeType::Aircraft),
-            x if x == NodeType::Waypoint as i32 => Ok(NodeType::Waypoint),
-            _ => Err(()),
-        }
-    }
-}
-
-impl TryFrom<i32> for GrpcNodeType {
-    type Error = ();
-    fn try_from(v: i32) -> Result<Self, Self::Error> {
-        match v {
-            x if x == GrpcNodeType::Vertiport as i32 => Ok(GrpcNodeType::Vertiport),
-            x if x == GrpcNodeType::Aircraft as i32 => Ok(GrpcNodeType::Aircraft),
-            x if x == GrpcNodeType::Waypoint as i32 => Ok(GrpcNodeType::Waypoint),
-            _ => Err(()),
-        }
-    }
-}
-
-impl From<NodeType> for GrpcNodeType {
-    fn from(node_type: NodeType) -> Self {
-        match node_type {
-            NodeType::Vertiport => GrpcNodeType::Vertiport,
-            NodeType::Waypoint => GrpcNodeType::Waypoint,
-            NodeType::Aircraft => GrpcNodeType::Aircraft,
-        }
-    }
-}
-
-impl From<GrpcNodeType> for NodeType {
-    fn from(node_type: GrpcNodeType) -> Self {
-        match node_type {
-            GrpcNodeType::Vertiport => NodeType::Vertiport,
-            GrpcNodeType::Waypoint => NodeType::Waypoint,
-            GrpcNodeType::Aircraft => NodeType::Aircraft,
-        }
-    }
 }

--- a/server/src/postgis/mod.rs
+++ b/server/src/postgis/mod.rs
@@ -3,17 +3,30 @@
 #[macro_use]
 pub mod macros;
 pub mod aircraft;
+pub mod best_path;
+pub mod nearest;
 pub mod nofly;
 pub mod pool;
-pub mod routing;
 pub mod utils;
 pub mod vertiport;
 pub mod waypoint;
 
+use crate::grpc::server::NodeType as GrpcNodeType;
 use postgres_types::FromSql;
 
+/// Routing can occur from a vertiport to a vertiport
+/// Or an aircraft to a vertiport (in-flight re-routing)
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum PathType {
+    /// Route between vertiports
+    PortToPort = 0,
+
+    /// Route from an aircraft to a vertiport
+    AircraftToPort = 1,
+}
+
 /// Types of nodes returned by the routing algorithm
-#[derive(Debug, Copy, Clone, FromSql)]
+#[derive(Debug, Copy, Clone, FromSql, PartialEq)]
 #[postgres(name = "nodetype")]
 pub enum NodeType {
     /// Vertiport Node
@@ -29,12 +42,46 @@ pub enum NodeType {
     Aircraft,
 }
 
-impl From<NodeType> for crate::grpc::server::NodeType {
+impl TryFrom<i32> for NodeType {
+    type Error = ();
+    fn try_from(v: i32) -> Result<Self, Self::Error> {
+        match v {
+            x if x == NodeType::Vertiport as i32 => Ok(NodeType::Vertiport),
+            x if x == NodeType::Aircraft as i32 => Ok(NodeType::Aircraft),
+            x if x == NodeType::Waypoint as i32 => Ok(NodeType::Waypoint),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<i32> for GrpcNodeType {
+    type Error = ();
+    fn try_from(v: i32) -> Result<Self, Self::Error> {
+        match v {
+            x if x == GrpcNodeType::Vertiport as i32 => Ok(GrpcNodeType::Vertiport),
+            x if x == GrpcNodeType::Aircraft as i32 => Ok(GrpcNodeType::Aircraft),
+            x if x == GrpcNodeType::Waypoint as i32 => Ok(GrpcNodeType::Waypoint),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<NodeType> for GrpcNodeType {
     fn from(node_type: NodeType) -> Self {
         match node_type {
-            NodeType::Vertiport => crate::grpc::server::NodeType::Vertiport,
-            NodeType::Waypoint => crate::grpc::server::NodeType::Waypoint,
-            NodeType::Aircraft => crate::grpc::server::NodeType::Aircraft,
+            NodeType::Vertiport => GrpcNodeType::Vertiport,
+            NodeType::Waypoint => GrpcNodeType::Waypoint,
+            NodeType::Aircraft => GrpcNodeType::Aircraft,
+        }
+    }
+}
+
+impl From<GrpcNodeType> for NodeType {
+    fn from(node_type: GrpcNodeType) -> Self {
+        match node_type {
+            GrpcNodeType::Vertiport => NodeType::Vertiport,
+            GrpcNodeType::Waypoint => NodeType::Waypoint,
+            GrpcNodeType::Aircraft => NodeType::Aircraft,
         }
     }
 }

--- a/server/src/postgis/nearest.rs
+++ b/server/src/postgis/nearest.rs
@@ -1,0 +1,361 @@
+//! This module contains functions for routing between nodes.
+use crate::grpc::server::grpc_server::{
+    DistanceTo, NearestNeighborRequest, NodeType as GrpcNodeType,
+};
+
+use crate::postgis::NodeType;
+use uuid::Uuid;
+
+/// Possible errors with path requests
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum NNError {
+    /// No path was found
+    NoPath,
+
+    /// Invalid start node
+    InvalidStartNode,
+
+    /// Invalid end node
+    InvalidEndNode,
+
+    /// Invalid limit
+    InvalidLimit,
+
+    /// Invalid range
+    InvalidRange,
+
+    /// Unsupported path type
+    Unsupported,
+
+    /// Could not get client
+    Client,
+
+    /// Unknown error
+    Unknown,
+}
+
+impl std::fmt::Display for NNError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            NNError::NoPath => write!(f, "No path was found."),
+            NNError::InvalidStartNode => write!(f, "Invalid start node."),
+            NNError::InvalidEndNode => write!(f, "Invalid end node."),
+            NNError::InvalidLimit => write!(f, "Invalid limit."),
+            NNError::InvalidRange => write!(f, "Invalid range."),
+            NNError::Unsupported => write!(f, "Unsupported path type."),
+            NNError::Client => write!(f, "Could not get client."),
+            NNError::Unknown => write!(f, "Unknown error."),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct NNRequest {
+    node_start_id: String,
+    start_type: NodeType,
+    end_type: NodeType,
+    limit: i32,
+    max_range_meters: f64,
+}
+
+/// Sanitize the request inputs
+fn sanitize(request: NearestNeighborRequest) -> Result<NNRequest, NNError> {
+    let Ok(start_type) = NodeType::try_from(request.start_type) else {
+        postgis_error!(
+            "(sanitize) invalid start node type: {:?}",
+            request.start_type
+        );
+
+        return Err(NNError::InvalidStartNode);
+    };
+
+    let Ok(end_type) = NodeType::try_from(request.end_type) else {
+        postgis_error!("(sanitize) invalid end node type: {:?}", request.end_type);
+        return Err(NNError::InvalidEndNode);
+    };
+
+    match start_type {
+        NodeType::Vertiport => {
+            uuid::Uuid::parse_str(&request.start_node_id).map_err(|_| NNError::InvalidStartNode)?;
+        }
+        NodeType::Aircraft => {
+            crate::postgis::aircraft::check_callsign(&request.start_node_id)
+                .map_err(|_| NNError::InvalidStartNode)?;
+        }
+        _ => {
+            postgis_error!("(sanitize) invalid start node type: {:?}", start_type);
+            return Err(NNError::Unsupported);
+        }
+    }
+
+    if end_type != NodeType::Vertiport {
+        postgis_error!("(sanitize) invalid end node type: {:?}", end_type);
+        return Err(NNError::Unsupported);
+    }
+
+    if request.limit < 1 {
+        postgis_error!("(sanitize) invalid limit: {}", request.limit);
+        return Err(NNError::InvalidLimit);
+    }
+
+    if request.max_range_meters < 0.0 {
+        postgis_error!(
+            "(sanitize) invalid max range meters: {}",
+            request.max_range_meters
+        );
+        return Err(NNError::InvalidRange);
+    }
+
+    let node_start_id = request.start_node_id;
+    Ok(NNRequest {
+        node_start_id,
+        start_type,
+        end_type,
+        limit: request.limit,
+        max_range_meters: request.max_range_meters as f64,
+    })
+}
+
+/// Get the best path from a vertiport to another vertiport
+async fn nearest_neighbor_vertiport_source(
+    stmt: tokio_postgres::Statement,
+    client: deadpool_postgres::Client,
+    request: NNRequest,
+) -> Result<Vec<tokio_postgres::Row>, NNError> {
+    let Ok(node_start_id) = Uuid::parse_str(&request.node_start_id) else {
+        postgis_error!("(nearest_neighbor_vertiport_source) could not parse start node id into UUID: {}", request.node_start_id);
+        return Err(NNError::InvalidStartNode);
+    };
+
+    match client
+        .query(
+            &stmt,
+            &[&node_start_id, &request.limit, &request.max_range_meters],
+        )
+        .await
+    {
+        Ok(results) => Ok(results),
+        Err(e) => {
+            println!(
+                "(nearest_neighbor_vertiport_source) could not request routes: {}",
+                e
+            );
+            return Err(NNError::Unknown);
+        }
+    }
+}
+
+/// Get the best path from a aircraft to another vertiport
+async fn nearest_neighbor_aircraft_source(
+    stmt: tokio_postgres::Statement,
+    client: deadpool_postgres::Client,
+    request: NNRequest,
+) -> Result<Vec<tokio_postgres::Row>, NNError> {
+    match client
+        .query(
+            &stmt,
+            &[
+                &request.node_start_id,
+                &request.limit,
+                &request.max_range_meters,
+            ],
+        )
+        .await
+    {
+        Ok(results) => Ok(results),
+        Err(e) => {
+            println!(
+                "(nearest_neighbor_aircraft_source) could not request routes: {}",
+                e
+            );
+            return Err(NNError::Unknown);
+        }
+    }
+}
+
+/// Nearest neighbor query for nodes
+#[cfg(not(tarpaulin_include))]
+pub async fn nearest_neighbors(
+    request: NearestNeighborRequest,
+    pool: deadpool_postgres::Pool,
+) -> Result<Vec<DistanceTo>, NNError> {
+    let request = sanitize(request)?;
+
+    let Ok(client) = pool.get().await else {
+        println!("(nearest_neighbors) could not get client from pool.");
+        return Err(NNError::Client);
+    };
+
+    let rows = match (request.start_type, request.end_type) {
+        (NodeType::Vertiport, NodeType::Vertiport) => {
+            let Ok(stmt) = client.prepare_cached(&format!(
+                "SELECT * FROM arrow.nearest_vertiports_to_vertiport($1, $2, $3);",
+            )).await else {
+                postgis_error!("(nearest_neighbors) could not prepare statement.");
+                return Err(NNError::Unknown);
+            };
+
+            nearest_neighbor_vertiport_source(stmt, client, request).await?
+        }
+        (NodeType::Aircraft, NodeType::Vertiport) => {
+            let Ok(stmt) = client.prepare_cached(&format!(
+                "SELECT * FROM arrow.nearest_vertiports_to_aircraft($1, $2, $3);",
+            )).await else {
+                postgis_error!("(nearest_neighbors) could not prepare statement.");
+                return Err(NNError::Unknown);
+            };
+
+            nearest_neighbor_aircraft_source(stmt, client, request).await?
+        }
+        _ => {
+            postgis_error!("(grpc nearest_neighbors) unsupported path type");
+            return Err(NNError::Unsupported);
+        }
+    };
+
+    let mut results: Vec<DistanceTo> = vec![];
+    for r in &rows {
+        let label: Uuid = r.get(0);
+        let distance_meters: f64 = r.get(1);
+
+        results.push(DistanceTo {
+            label: label.to_string(),
+            target_type: GrpcNodeType::Vertiport as i32,
+            distance_meters: distance_meters as f32,
+        });
+    }
+
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grpc::server::grpc_server;
+
+    #[test]
+    fn ut_sanitize_valid() {
+        let request = NearestNeighborRequest {
+            start_node_id: uuid::Uuid::new_v4().to_string(),
+            start_type: grpc_server::NodeType::Vertiport as i32,
+            end_type: grpc_server::NodeType::Vertiport as i32,
+            limit: 10,
+            max_range_meters: 1000.0,
+        };
+
+        let result = sanitize(request);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn ut_sanitize_valid_aircraft_start() {
+        let request = NearestNeighborRequest {
+            start_node_id: "test".to_string(),
+            start_type: grpc_server::NodeType::Aircraft as i32,
+            end_type: grpc_server::NodeType::Vertiport as i32,
+            limit: 10,
+            max_range_meters: 1000.0,
+        };
+
+        let result = sanitize(request);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn ut_sanitize_invalid_uuids() {
+        let request = NearestNeighborRequest {
+            start_node_id: "Invalid".to_string(),
+            start_type: grpc_server::NodeType::Vertiport as i32,
+            end_type: grpc_server::NodeType::Vertiport as i32,
+            limit: 10,
+            max_range_meters: 1000.0,
+        };
+
+        let result = sanitize(request).unwrap_err();
+        assert_eq!(result, NNError::InvalidStartNode);
+    }
+
+    #[test]
+    fn ut_sanitize_invalid_aircraft() {
+        let request = NearestNeighborRequest {
+            start_node_id: "Test-123!".to_string(),
+            start_type: grpc_server::NodeType::Aircraft as i32,
+            end_type: grpc_server::NodeType::Vertiport as i32,
+            limit: 10,
+            max_range_meters: 1000.0,
+        };
+
+        let result = sanitize(request).unwrap_err();
+        assert_eq!(result, NNError::InvalidStartNode);
+    }
+
+    #[test]
+    fn ut_sanitize_invalid_start_node() {
+        let request = NearestNeighborRequest {
+            start_node_id: "Aircraft".to_string(),
+            start_type: grpc_server::NodeType::Waypoint as i32,
+            end_type: grpc_server::NodeType::Vertiport as i32,
+            limit: 10,
+            max_range_meters: 1000.0,
+        };
+
+        let result = sanitize(request).unwrap_err();
+        assert_eq!(result, NNError::Unsupported);
+    }
+
+    #[test]
+    fn ut_sanitize_invalid_end_node() {
+        let request = NearestNeighborRequest {
+            start_node_id: uuid::Uuid::new_v4().to_string(),
+            start_type: grpc_server::NodeType::Vertiport as i32,
+            end_type: grpc_server::NodeType::Waypoint as i32,
+            limit: 10,
+            max_range_meters: 1000.0,
+        };
+
+        let result = sanitize(request).unwrap_err();
+        assert_eq!(result, NNError::Unsupported);
+    }
+
+    #[test]
+    fn ut_sanitize_invalid_limit() {
+        let request = NearestNeighborRequest {
+            start_node_id: uuid::Uuid::new_v4().to_string(),
+            start_type: grpc_server::NodeType::Vertiport as i32,
+            end_type: grpc_server::NodeType::Vertiport as i32,
+            limit: 0,
+            max_range_meters: 1000.0,
+        };
+
+        let result = sanitize(request).unwrap_err();
+        assert_eq!(result, NNError::InvalidLimit);
+    }
+
+    #[test]
+    fn ut_sanitize_invalid_range() {
+        let request = NearestNeighborRequest {
+            start_node_id: uuid::Uuid::new_v4().to_string(),
+            start_type: grpc_server::NodeType::Vertiport as i32,
+            end_type: grpc_server::NodeType::Vertiport as i32,
+            limit: 10,
+            max_range_meters: -1.0,
+        };
+
+        let result = sanitize(request).unwrap_err();
+        assert_eq!(result, NNError::InvalidRange);
+    }
+
+    #[test]
+    fn ut_sanitize_invalid_path_type() {
+        let request = NearestNeighborRequest {
+            start_node_id: uuid::Uuid::new_v4().to_string(),
+            start_type: grpc_server::NodeType::Aircraft as i32,
+            end_type: grpc_server::NodeType::Aircraft as i32,
+            limit: 10,
+            max_range_meters: 1000.0,
+        };
+
+        let result = sanitize(request).unwrap_err();
+        assert_eq!(result, NNError::Unsupported);
+    }
+}


### PR DESCRIPTION
svc-scheduler uses its router to get the nearest vertiports to an aircraft or vertiport. Can replace with a call to svc-gis

Outcome of example:

🏠 Nearest Vertiport Neighbors to Vertiport
RESPONSE=NearestNeighborResponse { distances: [DistanceTo { label: "00000000-0000-0000-0000-000000000001", target_type: Vertiport, distance_meters: 50.955315 }, DistanceTo { label: "00000000-0000-0000-0000-000000000003", target_type: Vertiport, distance_meters: 73.30564 }] }
**2 nearest neighbors(s).**

🏠 Nearest Vertiport Neighbors to Aircraft
RESPONSE=NearestNeighborResponse { distances: [DistanceTo { label: "00000000-0000-0000-0000-000000000000", target_type: Vertiport, distance_meters: 29.386684 }, DistanceTo { label: "00000000-0000-0000-0000-000000000001", target_type: Vertiport, distance_meters: 70.63113 }, DistanceTo { label: "00000000-0000-0000-0000-000000000003", target_type: Vertiport, distance_meters: 79.33099 }] }
**3 nearest neighbors(s).**

