### PR TITLE
Confirmed Flight Paths

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -85,6 +85,8 @@ rotorcraft
 kamino
 bespin
 coruscant
+fondor
+rideshare
 powf
 sfcgal
 centroidz

--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -89,6 +89,7 @@ powf
 sfcgal
 centroidz
 linestring
+linestringz
 polyhedralsurfacez
 loglevel
 flushdb

--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -102,3 +102,4 @@ rpush
 typname
 segmentize
 segmentizing
+formatcp

--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -100,3 +100,5 @@ nanos
 rpop
 rpush
 typname
+segmentize
+segmentizing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,6 +2367,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "deadpool-postgres",
+ "geo",
  "lib-common",
  "log",
  "num-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2323,6 +2343,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "const_format",
  "deadpool-postgres",
  "deadpool-redis",
  "dotenv",
@@ -2806,6 +2827,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-any-ors"

--- a/client-grpc/Cargo.toml
+++ b/client-grpc/Cargo.toml
@@ -56,6 +56,7 @@ git      = "https://github.com/Arrow-air/lib-common.git"
 tag      = "v0.2.1-develop.0"
 
 [dev-dependencies]
+geo  = "0.27.0"
 rand = "0.8"
 
 [dependencies.tokio]

--- a/client-grpc/src/client.rs
+++ b/client-grpc/src/client.rs
@@ -28,7 +28,7 @@ cfg_if::cfg_if! {
                 cfg.dbname = Some("deadpool".to_string());
                 cfg.manager = Some(ManagerConfig { recycling_method: RecyclingMethod::Fast });
 
-                let pool = cfg.create_pool(Some(Runtime::Tokio1), NoTls).unwrap();
+                let _pool = cfg.create_pool(Some(Runtime::Tokio1), NoTls).unwrap();
                 let grpc_service = ServerImpl { };
                 lib_common::grpc::mock::start_mock_server(
                     server,

--- a/client-grpc/tests/integration_test.rs
+++ b/client-grpc/tests/integration_test.rs
@@ -13,9 +13,9 @@ const AIRCRAFT_1_ID: &str = "00000000-0000-0000-0000-000000000002";
 #[tokio::test]
 async fn test_add_aircraft() -> Result<(), ()> {
     let (server_host, server_port) = get_endpoint_from_env("GRPC_HOST", "GRPC_PORT");
-    let client = GisClient::new_client(&server_host, server_port, "compliance");
+    let _client = GisClient::new_client(&server_host, server_port, "compliance");
 
-    let sample: Vec<(&str, f64, f64, f32)> = vec![
+    let _sample: Vec<(&str, f64, f64, f32)> = vec![
         (AIRCRAFT_1_ID, 52.3746, 4.9160036, 100.0),
         ("Mantis", 52.3749819, 4.9157, 120.0),
         ("Ghost", 52.37523, 4.9153733, 30.0),

--- a/common/types.rs
+++ b/common/types.rs
@@ -10,6 +10,9 @@ pub const REDIS_KEY_AIRCRAFT_POSITION: &str = "gis:aircraft:position";
 /// The key for the Redis queue containing aircraft velocity information
 pub const REDIS_KEY_AIRCRAFT_VELOCITY: &str = "gis:aircraft:velocity";
 
+/// The key for the Redis queue containing flight path information
+pub const REDIS_KEY_FLIGHT_PATH: &str = "gis:flight";
+
 /// Aircraft Type
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 #[derive(strum::EnumString)]
@@ -163,9 +166,9 @@ pub struct FlightPath {
     /// The path of the aircraft
     pub path: Vec<Position>,
 
-    /// The network timestamp of the flight path
+    /// The planned start time of the flight
     pub timestamp_start: DateTime<Utc>,
 
-    /// The network timestamp of the flight path
-    pub timestamp_end: Option<DateTime<Utc>>,
+    /// The planned end time of the flight
+    pub timestamp_end: DateTime<Utc>,
 }

--- a/common/types.rs
+++ b/common/types.rs
@@ -144,3 +144,28 @@ pub struct AircraftVelocity {
 
     // TODO(R5): velocity uncertainty
 }
+
+/// A flight path is a series of positions and times that an aircraft will follow
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FlightPath {
+    /// The unique identifier for the flight
+    pub flight_identifier: String,
+
+    /// The unique identifier for the aircraft
+    pub aircraft_identifier: String,
+
+    /// If this is a simulated flight
+    pub simulated: bool,
+
+    /// The type of aircraft
+    pub aircraft_type: AircraftType,
+
+    /// The path of the aircraft
+    pub path: Vec<Position>,
+
+    /// The network timestamp of the flight path
+    pub timestamp_start: DateTime<Utc>,
+
+    /// The network timestamp of the flight path
+    pub timestamp_end: Option<DateTime<Utc>>,
+}

--- a/log4rs.yaml
+++ b/log4rs.yaml
@@ -55,7 +55,7 @@ root:
 
 loggers:
   backend::postgis:
-    level: info
+    level: debug
     appenders:
       - backend_requests
   app::grpc:

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -31,6 +31,7 @@ cargo-husky         = "1"
 chrono              = { version = "0.4", features = ["serde"] }
 clap                = { version = "4.4", features = ["derive"] }
 config              = "0.13"
+const_format        = "0.2"
 deadpool-postgres   = { version = "0.11", features = ["serde"] }
 deadpool-redis      = { version = "0.14", features = ["serde"] }
 dotenv              = "0.15"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,5 @@
 //! Main function starting the server and initializing dependencies.
 
-use crate::postgis::psql_maintenance;
 use crate::types::{
     AircraftId, AircraftPosition, AircraftVelocity, FlightPath, REDIS_KEY_AIRCRAFT_ID,
     REDIS_KEY_AIRCRAFT_POSITION, REDIS_KEY_AIRCRAFT_VELOCITY, REDIS_KEY_FLIGHT_PATH,
@@ -61,12 +60,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     postgis::psql_init().await?;
-
-    // Start the maintenance threads
-    if psql_maintenance().await.is_err() {
-        log::error!("(main) Could not start maintenance threads.");
-        panic!("Could not start maintenance threads.");
-    }
 
     // Start the Redis consumers
     if start_redis_consumers(&config).await.is_err() {

--- a/server/src/postgis/aircraft.rs
+++ b/server/src/postgis/aircraft.rs
@@ -2,6 +2,7 @@
 
 use super::psql_transaction;
 use super::PostgisError;
+use super::DEFAULT_SRID;
 use crate::cache::{Consumer, Processor};
 use crate::postgis::utils::StringError;
 use chrono::{DateTime, Utc};
@@ -68,7 +69,7 @@ pub async fn psql_init() -> Result<(), PostgisError> {
                 velocity_horizontal_air_mps FLOAT(4),
                 velocity_vertical_mps FLOAT(4),
                 track_angle_degrees FLOAT(4),
-                geom GEOMETRY(POINTZ, 4326),
+                geom GEOMETRY(POINTZ, {DEFAULT_SRID}),
                 last_identifier_update TIMESTAMPTZ,
                 last_position_update TIMESTAMPTZ,
                 last_velocity_update TIMESTAMPTZ
@@ -83,6 +84,10 @@ pub async fn psql_init() -> Result<(), PostgisError> {
 #[async_trait]
 impl Processor<AircraftId> for Consumer {
     async fn process(&mut self, items: Vec<AircraftId>) -> Result<(), ()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+
         update_aircraft_id(items).await.map_err(|_| ())
     }
 }
@@ -90,6 +95,10 @@ impl Processor<AircraftId> for Consumer {
 #[async_trait]
 impl Processor<AircraftPosition> for Consumer {
     async fn process(&mut self, items: Vec<AircraftPosition>) -> Result<(), ()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+
         update_aircraft_position(items).await.map_err(|_| ())
     }
 }
@@ -97,6 +106,10 @@ impl Processor<AircraftPosition> for Consumer {
 #[async_trait]
 impl Processor<AircraftVelocity> for Consumer {
     async fn process(&mut self, items: Vec<AircraftVelocity>) -> Result<(), ()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+
         update_aircraft_velocity(items).await.map_err(|_| ())
     }
 }

--- a/server/src/postgis/aircraft.rs
+++ b/server/src/postgis/aircraft.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use postgis::ewkb::PointZ;
 use tonic::async_trait;
 
-use crate::types::{AircraftId, AircraftPosition, AircraftType, AircraftVelocity};
+use crate::types::{AircraftId, AircraftPosition, AircraftType, AircraftVelocity, Position};
 
 /// Allowed characters in a identifier
 pub const IDENTIFIER_REGEX: &str = r"^[\-0-9A-Za-z_\.]{1,255}$";

--- a/server/src/postgis/flight.rs
+++ b/server/src/postgis/flight.rs
@@ -1,11 +1,8 @@
 //! This module contains functions for updating aircraft flight paths in the PostGIS database.
 
-use super::psql_transaction;
-use super::PostgisError;
-use super::DEFAULT_SRID;
+use super::{psql_transaction, PostgisError, DEFAULT_SRID, PSQL_SCHEMA};
 use crate::cache::{Consumer, Processor};
 use crate::postgis::utils::StringError;
-use chrono::{Duration, Utc};
 use deadpool_postgres::Object;
 use postgis::ewkb::{LineStringT, PointZ};
 use tonic::async_trait;
@@ -50,6 +47,17 @@ impl std::fmt::Display for FlightPathError {
     }
 }
 
+/// Gets the name of the flights table
+fn get_flights_table_name() -> &'static str {
+    static FULL_NAME: &str = const_format::formatcp!(r#""{PSQL_SCHEMA}"."flights""#,);
+    FULL_NAME
+}
+/// Gets the name of the flight segments table
+fn get_flight_segments_table_name() -> &'static str {
+    static FULL_NAME: &str = const_format::formatcp!(r#""{PSQL_SCHEMA}"."flight_segments""#,);
+    FULL_NAME
+}
+
 /// Verifies that a identifier is valid
 pub fn check_flight_identifier(identifier: &str) -> Result<(), StringError> {
     super::utils::check_string(identifier, FLIGHT_IDENTIFIER_REGEX)
@@ -61,104 +69,41 @@ pub async fn psql_init() -> Result<(), PostgisError> {
     let enum_name = "aircrafttype";
     let statements = vec![
         // super::psql_enum_declaration::<AircraftType>(enum_name), // should already exist
-        format!("CREATE TABLE IF NOT EXISTS {schema}.flights (
-                flight_identifier VARCHAR(20) UNIQUE PRIMARY KEY NOT NULL,
-                aircraft_identifier VARCHAR(20) NOT NULL,
-                aircraft_type {enum_name} NOT NULL DEFAULT '{aircraft_type}',
-                simulated BOOLEAN NOT NULL DEFAULT FALSE,
-                geom GEOMETRY(LINESTRINGZ, {DEFAULT_SRID}), -- full path
-                isa GEOMETRY NOT NULL, -- envelope
-                time_start TIMESTAMPTZ,
-                time_end TIMESTAMPTZ
-            );", schema = super::PSQL_SCHEMA, enum_name = enum_name, aircraft_type = AircraftType::Undeclared.to_string()),
-        format!("CREATE TABLE IF NOT EXISTS {schema}.flight_segments (
-                flight_identifier VARCHAR(20) NOT NULL,
-                geom GEOMETRY(LINESTRINGZ, {DEFAULT_SRID}),
-                time_start TIMESTAMPTZ,
-                time_end TIMESTAMPTZ,
-                PRIMARY KEY (flight_identifier, time_start)
-            );", schema = super::PSQL_SCHEMA),
-        format!("CREATE INDEX IF NOT EXISTS flights_geom_idx ON {schema}.flights USING GIST (isa);", schema = super::PSQL_SCHEMA),
-        format!("CREATE INDEX IF NOT EXISTS flight_paths_idx ON {schema}.flight_segments USING GIST (ST_Transform(geom, 4978));", schema = super::PSQL_SCHEMA),
+        format!(
+            r#"CREATE TABLE IF NOT EXISTS {table_name} (
+                "flight_identifier" VARCHAR(20) UNIQUE PRIMARY KEY NOT NULL,
+                "aircraft_identifier" VARCHAR(20) NOT NULL,
+                "aircraft_type" {enum_name} NOT NULL DEFAULT '{aircraft_type}',
+                "simulated" BOOLEAN NOT NULL DEFAULT FALSE,
+                "geom" GEOMETRY(LINESTRINGZ, {DEFAULT_SRID}), -- full path
+                "isa" GEOMETRY NOT NULL, -- envelope
+                "time_start" TIMESTAMPTZ,
+                "time_end" TIMESTAMPTZ
+            );"#,
+            table_name = get_flights_table_name(),
+            aircraft_type = AircraftType::Undeclared.to_string()
+        ),
+        format!(
+            r#"CREATE TABLE IF NOT EXISTS {table_name} (
+                "flight_identifier" VARCHAR(20) NOT NULL,
+                "geom" GEOMETRY(LINESTRINGZ, {DEFAULT_SRID}),
+                "time_start" TIMESTAMPTZ,
+                "time_end" TIMESTAMPTZ,
+                PRIMARY KEY ("flight_identifier", "time_start")
+            );"#,
+            table_name = get_flight_segments_table_name()
+        ),
+        format!(
+            r#"CREATE INDEX IF NOT EXISTS "flights_geom_idx" ON {table_name} USING GIST ("isa");"#,
+            table_name = get_flights_table_name()
+        ),
+        format!(
+            r#"CREATE INDEX IF NOT EXISTS "flight_segments_geom_idx" ON {table_name} USING GIST (ST_Transform("geom", 4978));"#,
+            table_name = get_flight_segments_table_name()
+        ),
     ];
 
     psql_transaction(statements).await
-}
-
-/// Commits a transaction to the PostGIS database to clean up old flights
-async fn cleanup(pool: &deadpool_postgres::Pool) -> Result<(), PostgisError> {
-    // TODO(R5): Config setting
-    const DURATION_H: i64 = 6;
-    let expiration = Utc::now() - Duration::hours(DURATION_H);
-    let stmts = vec![
-        format!(
-            "DELETE FROM {schema}.flight_segments WHERE time_end < $1;",
-            schema = super::PSQL_SCHEMA
-        ),
-        format!(
-            "DELETE FROM {schema}.flights WHERE time_end < $1;",
-            schema = super::PSQL_SCHEMA
-        ),
-    ];
-
-    let mut client = pool.get().await.map_err(|e| {
-        postgis_error!(
-            "(flight::cleanup) could not get client from psql connection pool: {}",
-            e
-        );
-        PostgisError::FlightPath(FlightPathError::Client)
-    })?;
-
-    let transaction = client.transaction().await.map_err(|e| {
-        postgis_error!("(flight::cleanup) could not create transaction: {}", e);
-        PostgisError::FlightPath(FlightPathError::Client)
-    })?;
-
-    for stmt in &stmts {
-        transaction
-            .execute(stmt, &[&expiration])
-            .await
-            .map_err(|e| {
-                postgis_error!("(flight::cleanup) could not execute statement: {}", e);
-                PostgisError::FlightPath(FlightPathError::DBError)
-            })?;
-    }
-
-    transaction.commit().await.map_err(|e| {
-        postgis_error!("(flight::cleanup) could not commit transaction: {}", e);
-        PostgisError::FlightPath(FlightPathError::DBError)
-    })?;
-
-    Ok(())
-}
-
-/// Starts a thread that will remove old flights from the PostGIS flights table
-pub async fn psql_maintenance() -> Result<(), PostgisError> {
-    postgis_info!("(flight::psql_maintenance) start.");
-
-    // TODO(R5): Config setting
-    const SLEEP_S: u64 = 60;
-
-    let Some(pool) = crate::postgis::DEADPOOL_POSTGIS.get() else {
-        postgis_error!("(flight::psql_maintenance) could not get psql pool.");
-        return Err(PostgisError::FlightPath(FlightPathError::DBError));
-    };
-
-    // Remove flights from postgis that are older than N hours
-    tokio::spawn(async move {
-        loop {
-            postgis_info!("(flight::psql_maintenance) running scheduled maintenance.");
-
-            if let Err(e) = cleanup(pool).await {
-                postgis_error!("(flight::psql_maintenance) could not cleanup: {}", e);
-            }
-
-            tokio::time::sleep(tokio::time::Duration::from_secs(SLEEP_S)).await;
-        }
-    });
-
-    postgis_info!("(flight::psql_maintenance) successfully launched thread.");
-    Ok(())
 }
 
 #[async_trait]
@@ -195,41 +140,41 @@ pub async fn update_flight_path(flights: Vec<FlightPath>) -> Result<(), PostgisE
     }
 
     let flights_insertion_stmt: String = format!(
-        "INSERT INTO {schema}.flights (
-            flight_identifier,
-            aircraft_identifier,
-            aircraft_type,
-            simulated,
-            time_start,
-            time_end,
-            geom,
-            isa
+        r#"INSERT INTO {table_name} (
+            "flight_identifier",
+            "aircraft_identifier",
+            "aircraft_type",
+            "simulated",
+            "time_start",
+            "time_end",
+            "geom",
+            "isa"
         )
         VALUES ($1, $2, $3, $4, $5, $6, $7, ST_Envelope($7))
-        ON CONFLICT (flight_identifier) DO UPDATE
-            SET aircraft_identifier = EXCLUDED.aircraft_identifier,
-                aircraft_type = EXCLUDED.aircraft_type,
-                simulated = EXCLUDED.simulated,
-                geom = EXCLUDED.geom,
-                isa = (ST_Envelope(EXCLUDED.geom)),
-                time_start = EXCLUDED.time_start,
-                time_end = EXCLUDED.time_end;",
-        schema = super::PSQL_SCHEMA
+        ON CONFLICT ("flight_identifier") DO UPDATE
+            SET "aircraft_identifier" = EXCLUDED."aircraft_identifier",
+                "aircraft_type" = EXCLUDED."aircraft_type",
+                "simulated" = EXCLUDED."simulated",
+                "geom" = EXCLUDED."geom",
+                "isa" = EXCLUDED."isa",
+                "time_start" = EXCLUDED."time_start",
+                "time_end" = EXCLUDED."time_end";"#,
+        table_name = get_flights_table_name()
     );
 
     let segments_deletion_stmt = format!(
-        "DELETE FROM {schema}.flight_segments WHERE flight_identifier = $1;",
-        schema = super::PSQL_SCHEMA
+        r#"DELETE FROM {table_name} WHERE "flight_identifier" = $1;"#,
+        table_name = get_flight_segments_table_name()
     );
 
     let segment_insertion_stmt = format!(
-        "INSERT INTO {schema}.flight_segments (
-            flight_identifier,
-            geom,
-            time_start,
-            time_end
-        ) VALUES ( $1, $2, $3, $4 );",
-        schema = super::PSQL_SCHEMA
+        r#"INSERT INTO {table_name} (
+            "flight_identifier",
+            "geom",
+            "time_start",
+            "time_end"
+        ) VALUES ( $1, $2, $3, $4 );"#,
+        table_name = get_flight_segments_table_name()
     );
 
     let Some(pool) = crate::postgis::DEADPOOL_POSTGIS.get() else {
@@ -363,34 +308,34 @@ pub async fn get_flight_intersection_stmt(
 ) -> Result<tokio_postgres::Statement, PostgisError> {
     let result = client
         .prepare_cached(&format!(
-            "WITH segments AS (
-                SELECT (
-                    flight_identifier,
-                    geom,
-                    time_start,
-                    time_end
-                )
-                FROM {schema}.flight_segments
+            r#"WITH "segments" AS (
+                SELECT
+                    "flight_identifier",
+                    "geom",
+                    "time_start",
+                    "time_end"
+                FROM {segments_table_name}
                 WHERE
-                    (time_start <= $4 OR time_start IS NULL) -- easy checks first
-                    AND (time_end >= $3 OR time_end IS NULL)
+                    ("time_start" <= $4 OR "time_start" IS NULL) -- easy checks first
+                    AND ("time_end" >= $3 OR "time_end" IS NULL)
                     AND ST_3DDWithin(
-                        ST_Transform(geom, 4978),
+                        ST_Transform("geom", 4978),
                         ST_Transform($1, 4978),
                         $2 -- meters
                     )
             ) SELECT
-                flight_identifier,
-                aircraft_identifier,
-                geom,
-                time_start,
-                time_end
-            FROM {schema}.flights
-            WHERE flight_identifier IN (SELECT flight_identifier FROM segments)
-                AND simulated = FALSE
+                "flight_identifier",
+                "aircraft_identifier",
+                "geom",
+                "time_start",
+                "time_end"
+            FROM {flights_table_name}
+            WHERE "flight_identifier" IN (SELECT "flight_identifier" FROM "segments")
+                AND "simulated" = FALSE
             LIMIT 1;
-        ",
-            schema = super::PSQL_SCHEMA,
+        "#,
+            segments_table_name = get_flight_segments_table_name(),
+            flights_table_name = get_flights_table_name(),
         ))
         .await;
 
@@ -409,6 +354,7 @@ pub async fn get_flight_intersection_stmt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{Duration, Utc};
 
     #[tokio::test]
     async fn ut_client_failure() {

--- a/server/src/postgis/flight.rs
+++ b/server/src/postgis/flight.rs
@@ -1,0 +1,251 @@
+//! This module contains functions for updating aircraft flight paths in the PostGIS database.
+
+use super::psql_transaction;
+use super::PostgisError;
+use crate::postgis::utils::StringError;
+use postgis::ewkb::PointZ;
+
+use crate::types::{AircraftType, FlightPath};
+
+/// Allowed characters in a identifier
+pub const FLIGHT_IDENTIFIER_REGEX: &str = r"^[\-0-9A-Za-z_\.]{1,255}$";
+
+/// Possible errors with aircraft requests
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum FlightPathError {
+    /// Invalid Aircraft ID
+    AircraftId,
+
+    /// Invalid Location
+    Location,
+
+    /// Invalid Time Provided
+    Time,
+
+    /// Invalid Label
+    Label,
+
+    /// Could not get client
+    Client,
+
+    /// DBError error
+    DBError,
+}
+
+impl std::fmt::Display for FlightPathError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            FlightPathError::AircraftId => write!(f, "Invalid aircraft ID provided."),
+            FlightPathError::Location => write!(f, "Invalid location provided."),
+            FlightPathError::Time => write!(f, "Invalid time provided."),
+            FlightPathError::Label => write!(f, "Invalid label provided."),
+            FlightPathError::Client => write!(f, "Could not get backend client."),
+            FlightPathError::DBError => write!(f, "Unknown backend error."),
+        }
+    }
+}
+
+/// Verifies that a identifier is valid
+pub fn check_flight_identifier(identifier: &str) -> Result<(), StringError> {
+    super::utils::check_string(identifier, FLIGHT_IDENTIFIER_REGEX)
+}
+
+/// Initializes the PostGIS database for aircraft.
+pub async fn psql_init() -> Result<(), PostgisError> {
+    // Create Aircraft Table
+    let table_name = "arrow.flights";
+    let enum_name = "aircrafttype";
+    let statements = vec![
+        // super::psql_enum_declaration::<AircraftType>(enum_name), // should already exist
+        format!(
+            "CREATE TABLE IF NOT EXISTS {table_name} (
+                flight_identifier VARCHAR(20) UNIQUE PRIMARY KEY NOT NULL,
+                aircraft_identifier VARCHAR(20) NOT NULL,
+                aircraft_type {enum_name} NOT NULL DEFAULT '{}',
+                simulated BOOLEAN NOT NULL DEFAULT FALSE,
+                path GEOMETRY(LINESTRINGZ, 4326),
+                isa GEOMETRY NOT NULL,
+                start TIMESTAMPTZ,
+                end TIMESTAMPTZ,
+            );",
+            AircraftType::Undeclared.to_string()
+        ),
+    ];
+
+    psql_transaction(statements).await
+}
+
+/// Validates the provided aircraft identification.
+fn validate_flight_path(item: &FlightPath) -> Result<(), PostgisError> {
+    if let Err(e) = check_flight_identifier(&item.flight_identifier) {
+        postgis_error!(
+            "(validate_flight_path) invalid identifier {}: {}",
+            item.flight_identifier,
+            e
+        );
+
+        return Err(PostgisError::FlightPath(FlightPathError::Label));
+    }
+
+    Ok(())
+}
+
+/// Pulls queued flight path messages from Redis Queue (from svc-scheduler)
+pub async fn update_flight_path(flights: Vec<FlightPath>) -> Result<(), PostgisError> {
+    postgis_debug!("(update_flight_path) entry.");
+    if flights.is_empty() {
+        return Ok(());
+    }
+
+    let Some(pool) = crate::postgis::DEADPOOL_POSTGIS.get() else {
+        postgis_error!("(update_flight_path) could not get psql pool.");
+        return Err(PostgisError::FlightPath(FlightPathError::Client));
+    };
+
+    let mut client = pool.get().await.map_err(|e| {
+        postgis_error!(
+            "(update_flight_path) could not get client from psql connection pool: {}",
+            e
+        );
+
+        PostgisError::FlightPath(FlightPathError::Client)
+    })?;
+
+    let transaction = client.transaction().await.map_err(|e| {
+        postgis_error!("(update_flight_path) could not create transaction: {}", e);
+
+        PostgisError::FlightPath(FlightPathError::DBError)
+    })?;
+
+    let table_name = format!("{}.flights", super::PSQL_SCHEMA);
+    let stmt = transaction
+        .prepare_cached(&format!(
+            "
+        INSERT INTO {table_name}(
+            flight_identifier,
+            aircraft_identifier,
+            aircraft_type,
+            simulated,
+            path,
+            isa,
+            start,
+            end
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        ON CONFLICT (flight_identifier) DO UPDATE
+            SET aircraft_identifier = EXCLUDED.aircraft_identifier,
+                aircraft_type = EXCLUDED.aircraft_type,
+                simulated = EXCLUDED.simulated,
+                path = EXCLUDED.path,
+                isa = EXCLUDED.isa,
+                start = EXCLUDED.start,
+                end = EXCLUDED.end
+        ",
+        ))
+        .await
+        .map_err(|e| {
+            postgis_error!(
+                "(update_flight_path) could not prepare cached statement: {}",
+                e
+            );
+            PostgisError::FlightPath(FlightPathError::DBError)
+        })?;
+
+    for flight in &flights {
+        if let Err(e) = validate_flight_path(flight) {
+            postgis_error!(
+                "(update_flight_path) could not validate id for flight id {}: {:?}",
+                flight.flight_identifier,
+                e
+            );
+
+            // TODO(R5): Should we actually toss these out?
+            // Risk not registering a flight path on a clerical error and planning colliding paths
+            continue;
+        }
+
+        let points = flight
+            .path
+            .clone()
+            .into_iter()
+            .map(PointZ::try_from)
+            .collect::<Result<Vec<PointZ>, _>>()
+            .map_err(|_| {
+                postgis_error!("(update_flight_path) could not convert path to Vec<PointZ>.");
+
+                PostgisError::FlightPath(FlightPathError::Location)
+            })?;
+
+        let path = postgis::ewkb::LineStringT {
+            points,
+            srid: Some(4326),
+        };
+
+        // Draw bounding box around flight for ISA
+        // let isa = postgis::ewkb::Geometry::from(flight.isa.clone());
+        let isa: i32 = 1;
+
+        transaction
+            .execute(
+                &stmt,
+                &[
+                    &flight.flight_identifier,
+                    &flight.aircraft_identifier,
+                    &flight.aircraft_type,
+                    &flight.simulated,
+                    &path,
+                    &isa,
+                    &flight.timestamp_start,
+                    &flight.timestamp_end,
+                ],
+            )
+            .await
+            .map_err(|e| {
+                postgis_error!("(update_flight_path) could not execute transaction: {}", e);
+                PostgisError::FlightPath(FlightPathError::DBError)
+            })?;
+    }
+
+    match transaction.commit().await {
+        Ok(_) => {
+            postgis_debug!("(update_flight_path) success.");
+            Ok(())
+        }
+        Err(e) => {
+            postgis_error!("(update_flight_path) could not commit transaction: {}", e);
+            Err(PostgisError::FlightPath(FlightPathError::DBError))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[tokio::test]
+    async fn ut_client_failure() {
+        crate::get_log_handle().await;
+        ut_info!("(ut_client_failure) start");
+
+        let nodes = vec![("aircraft", 52.3745905, 4.9160036)];
+        let aircraft: Vec<AircraftPosition> = nodes
+            .iter()
+            .map(|(label, latitude, longitude)| AircraftPosition {
+                identifier: label.to_string(),
+                position: Position {
+                    latitude: *latitude,
+                    longitude: *longitude,
+                    altitude_meters: 100.0,
+                },
+                timestamp_network: Utc::now(),
+                timestamp_asset: None,
+            })
+            .collect();
+
+        let result = update_aircraft_position(aircraft).await.unwrap_err();
+        assert_eq!(result, PostgisError::FlightPath(FlightPathError::Client));
+
+        ut_info!("(ut_client_failure) success");
+    }
+}

--- a/server/src/postgis/mod.rs
+++ b/server/src/postgis/mod.rs
@@ -183,10 +183,3 @@ pub async fn psql_init() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
-
-/// Performs maintenance tasks (removing old records, etc.) on the PostgreSQL database
-pub async fn psql_maintenance() -> Result<(), Box<dyn std::error::Error>> {
-    flight::psql_maintenance().await?;
-
-    Ok(())
-}

--- a/server/src/postgis/mod.rs
+++ b/server/src/postgis/mod.rs
@@ -7,6 +7,7 @@ pub mod macros;
 // pub mod nearest;
 pub mod aircraft;
 pub mod best_path;
+pub mod flight;
 pub mod pool;
 pub mod utils;
 pub mod vertiport;
@@ -17,6 +18,9 @@ pub use once_cell::sync::OnceCell;
 
 /// Global pool for PostgreSQL connections
 pub static DEADPOOL_POSTGIS: OnceCell<deadpool_postgres::Pool> = OnceCell::new();
+
+/// PostgreSQL schema for all tables
+pub const PSQL_SCHEMA: &str = "arrow";
 
 /// Error type for postgis actions
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -38,6 +42,9 @@ pub enum PostgisError {
 
     /// BestPath Error
     BestPath(best_path::PathError),
+
+    /// FlightPath Error
+    FlightPath(flight::FlightPathError),
 }
 
 impl std::error::Error for PostgisError {
@@ -55,6 +62,7 @@ impl std::fmt::Display for PostgisError {
             PostgisError::Waypoint(e) => write!(f, "Waypoint Error: {}", e),
             PostgisError::Zone(e) => write!(f, "Zone Error: {}", e),
             PostgisError::BestPath(e) => write!(f, "BestPath Error: {}", e),
+            PostgisError::FlightPath(e) => write!(f, "FlightPath Error: {}", e),
         }
     }
 }
@@ -167,6 +175,7 @@ pub async fn psql_init() -> Result<(), Box<dyn std::error::Error>> {
     vertiport::psql_init().await?;
     aircraft::psql_init().await?;
     waypoint::psql_init().await?;
+    flight::psql_init().await?;
 
     Ok(())
 }

--- a/server/src/postgis/nearest.rs
+++ b/server/src/postgis/nearest.rs
@@ -180,7 +180,7 @@ pub async fn nearest_neighbors(
     let target_type = request.end_type;
     let rows = match (start_type, end_type) {
         (NodeType::Vertiport, NodeType::Vertiport) => {
-            let query = "SELECT * FROM arrow.nearest_vertiports_to_vertiport($1, $2, $3);";
+            let query = format!("SELECT * FROM {}.nearest_vertiports_to_vertiport($1, $2, $3);", super::PSQL_SCHEMA);
             postgis_debug!("(nearest_neighbors) query [{}]", query);
 
             let stmt = client.prepare_cached(query).await.map_err(|e| {
@@ -191,7 +191,7 @@ pub async fn nearest_neighbors(
             nearest_neighbor_vertiport_source(stmt, client, request).await?
         }
         (NodeType::Aircraft, NodeType::Vertiport) => {
-            let query = "SELECT * FROM arrow.nearest_vertiports_to_aircraft($1, $2, $3);";
+            let query = format!("SELECT * FROM {}.nearest_vertiports_to_aircraft($1, $2, $3);", super::PSQL_SCHEMA);
             postgis_debug!("(nearest_neighbors) query [{}]", query);
 
             let stmt = client.prepare_cached(query).await.map_err(|e| {

--- a/server/src/postgis/nearest.rs
+++ b/server/src/postgis/nearest.rs
@@ -2,6 +2,7 @@
 use crate::grpc::server::grpc_server::{DistanceTo, NearestNeighborRequest, NodeType};
 
 use uuid::Uuid;
+use super::PSQL_SCHEMA;
 
 /// Possible errors with path requests
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -180,7 +181,8 @@ pub async fn nearest_neighbors(
     let target_type = request.end_type;
     let rows = match (start_type, end_type) {
         (NodeType::Vertiport, NodeType::Vertiport) => {
-            let query = format!("SELECT * FROM {}.nearest_vertiports_to_vertiport($1, $2, $3);", super::PSQL_SCHEMA);
+            let query = format!(
+                r#"SELECT * FROM "{PSQL_SCHEMA}".nearest_vertiports_to_vertiport($1, $2, $3);"#);
             postgis_debug!("(nearest_neighbors) query [{}]", query);
 
             let stmt = client.prepare_cached(query).await.map_err(|e| {
@@ -191,7 +193,7 @@ pub async fn nearest_neighbors(
             nearest_neighbor_vertiport_source(stmt, client, request).await?
         }
         (NodeType::Aircraft, NodeType::Vertiport) => {
-            let query = format!("SELECT * FROM {}.nearest_vertiports_to_aircraft($1, $2, $3);", super::PSQL_SCHEMA);
+            let query = format!(r#"SELECT * FROM "{PSQL_SCHEMA}".nearest_vertiports_to_aircraft($1, $2, $3);"#);
             postgis_debug!("(nearest_neighbors) query [{}]", query);
 
             let stmt = client.prepare_cached(query).await.map_err(|e| {

--- a/server/src/postgis/utils.rs
+++ b/server/src/postgis/utils.rs
@@ -1,6 +1,7 @@
 //! Common functions for PostGIS operations
 
 use crate::grpc::server::grpc_server::Coordinates;
+use crate::types::Position;
 use geo::algorithm::haversine_distance::HaversineDistance;
 use geo::point;
 use postgis::ewkb::PointZ;
@@ -110,6 +111,19 @@ pub fn validate_pointz(point: &PointZ) -> Result<(), PolygonError> {
     }
 
     Ok(())
+}
+
+impl TryFrom<Position> for PointZ {
+    type Error = ();
+
+    fn try_from(position: Position) -> Result<Self, Self::Error> {
+        Ok(PointZ::new(
+            position.longitude,
+            position.latitude,
+            position.altitude_meters,
+            Some(4326),
+        ))
+    }
 }
 
 /// Generate a PostGIS Polygon from a list of vertices

--- a/server/src/postgis/vertiport.rs
+++ b/server/src/postgis/vertiport.rs
@@ -1,12 +1,12 @@
 //! Updates vertiports in the PostGIS database.
 
+use super::PostgisError;
+use super::DEFAULT_SRID;
 use crate::grpc::server::grpc_server;
 use chrono::{DateTime, Utc};
 use grpc_server::Vertiport as RequestVertiport;
 use grpc_server::ZoneType;
 use postgis::ewkb::PointZ;
-
-use super::PostgisError;
 
 /// Allowed characters in a label
 pub const IDENTIFIER_REGEX: &str = r"^[\-0-9A-Za-z_\.]{1,255}$";
@@ -180,7 +180,7 @@ pub async fn update_vertiports(vertiports: Vec<RequestVertiport>) -> Result<(), 
                 ) VALUES (
                     $1,
                     ST_EXTRUDE(
-                        $2::GEOMETRY(POLYGONZ, 4326),
+                        $2::GEOMETRY(POLYGONZ, {DEFAULT_SRID}),
                         0,
                         0,
                         ($4::FLOAT(4) - $3::FLOAT(4))
@@ -193,7 +193,7 @@ pub async fn update_vertiports(vertiports: Vec<RequestVertiport>) -> Result<(), 
                 ON CONFLICT (identifier) DO UPDATE
                 SET
                     geom = ST_EXTRUDE(
-                        $2::GEOMETRY(POLYGONZ, 4326),
+                        $2::GEOMETRY(POLYGONZ, {DEFAULT_SRID}),
                         0,
                         0,
                         ($4::FLOAT(4) - $3::FLOAT(4))


### PR DESCRIPTION
Need to track flight paths in postgis to determine intersection with other aircraft.

Features:
- [x] A new table "flights" that tracks
    - flight id
    - aircraft id
    - path (linestringZ)
    - isa (3D volume) 
        - simply the "envelope" of the path
    - time_start
    - time_end
- [x] Best path checks if a flight will intersect any existing flight paths (in addition to zone intersections)
    - Paths are broken into many smaller line segments with start/end times and compared for intersection.
    - e.g. Two flights have the same path with overlapping schedules, but one aircraft leaves 60 seconds earlier. The aircraft might never come within 30m of each other. With segmentized paths, aircraft A's first path segment might not overlap with aircraft B's first path segment because of the time separation, and so on
- [x] Auto-remove old flights from DB if time_end is in the past by more than N hours
    - svc-storage has long-term storage of flight details
- [x] Pull from redis queue to update flight paths instead of using gRPC interface 