### PR TITLE
feat: move flight path addition to grpc call

### DIFF
--- a/client-grpc/examples/grpc.rs
+++ b/client-grpc/examples/grpc.rs
@@ -236,14 +236,14 @@ async fn add_flight_paths(client: &GisClient) -> Result<(), ()> {
         .collect();
 
     for item in items {
-        client.update_flight_path(item).await.map_err(|e| ())?;
+        client.update_flight_path(item).await.map_err(|_| ())?;
     }
 
     Ok(())
 }
 
 async fn best_path_flight_avoidance(
-    connection: &mut redis::Connection,
+    _connection: &mut redis::Connection,
     client: &GisClient,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Add two vertiports specifically for this test
@@ -516,7 +516,7 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
     {
         println!("\n\u{1F426} Best Path WITHOUT Temporary No-Fly Zone");
         let time_start: Timestamp = Utc::now().into();
-        let time_end: Timestamp = (Utc::now() + Duration::hours(2)).into();
+        let time_end: Timestamp = (Utc::now() + Duration::try_hours(2).unwrap()).into();
         let request = BestPathRequest {
             origin_identifier: VERTIPORT_1_ID.to_string(),
             target_identifier: VERTIPORT_2_ID.to_string(),
@@ -534,7 +534,7 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
     }
 
     let no_fly_start_time = Utc::now();
-    let no_fly_end_time = Utc::now() + Duration::hours(2);
+    let no_fly_end_time = Utc::now() + Duration::try_hours(2).unwrap();
 
     // Update No-Fly Zones
     {
@@ -614,7 +614,7 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
     {
         println!("\n\u{26D4}\u{1F681} Best Path DURING Temporary No-Fly Zone");
         let time_start: Timestamp = no_fly_start_time.into();
-        let time_end: Timestamp = (no_fly_start_time + Duration::hours(1)).into();
+        let time_end: Timestamp = (no_fly_start_time + Duration::try_hours(1).unwrap()).into();
         let request = BestPathRequest {
             origin_identifier: VERTIPORT_1_ID.to_string(),
             target_identifier: VERTIPORT_2_ID.to_string(),
@@ -640,7 +640,7 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
     {
         println!("\n\u{1F681} Best Path AFTER Temporary No-Fly Zone Expires");
         let time_start: Timestamp = (no_fly_end_time + Duration::try_seconds(1).unwrap()).into();
-        let time_end: Timestamp = (no_fly_end_time + Duration::hours(1)).into();
+        let time_end: Timestamp = (no_fly_end_time + Duration::try_hours(1).unwrap()).into();
         let request = BestPathRequest {
             origin_identifier: VERTIPORT_1_ID.to_string(),
             target_identifier: VERTIPORT_2_ID.to_string(),
@@ -661,7 +661,7 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
     {
         println!("\n\u{1F681} Best Path From Aircraft during TFR");
         let time_start: Timestamp = no_fly_start_time.into();
-        let time_end: Timestamp = (no_fly_start_time + Duration::hours(1)).into();
+        let time_end: Timestamp = (no_fly_start_time + Duration::try_hours(1).unwrap()).into();
         let request = BestPathRequest {
             origin_identifier: AIRCRAFT_1_ID.to_string(),
             target_identifier: VERTIPORT_2_ID.to_string(),

--- a/client-grpc/src/client.rs
+++ b/client-grpc/src/client.rs
@@ -109,6 +109,15 @@ impl crate::service::Client<RpcServiceClient<Channel>> for GisClient {
         self.get_client().await?.update_zones(request).await
     }
 
+    async fn update_flight_path(
+        &self,
+        request: UpdateFlightPathRequest,
+    ) -> Result<tonic::Response<UpdateResponse>, tonic::Status> {
+        grpc_info!("(update_flight_path) {} client.", self.get_name());
+        grpc_debug!("(update_flight_path) request: {:?}", request);
+        self.get_client().await?.update_flight_path(request).await
+    }
+
     async fn best_path(
         &self,
         request: BestPathRequest,
@@ -176,6 +185,15 @@ impl crate::service::Client<RpcServiceClient<Channel>> for GisClient {
     ) -> Result<tonic::Response<UpdateResponse>, tonic::Status> {
         grpc_warn!("(update_zones MOCK) {} client.", self.get_name());
         grpc_debug!("(update_zones MOCK) request: {:?}", request);
+        Ok(tonic::Response::new(UpdateResponse { updated: true }))
+    }
+
+    async fn update_flight_path(
+        &self,
+        request: UpdateFlightPathRequest,
+    ) -> Result<tonic::Response<UpdateResponse>, tonic::Status> {
+        grpc_warn!("(update_flight_path MOCK) {} client.", self.get_name());
+        grpc_debug!("(update_flight_path MOCK) request: {:?}", request);
         Ok(tonic::Response::new(UpdateResponse { updated: true }))
     }
 

--- a/client-grpc/src/grpc.rs
+++ b/client-grpc/src/grpc.rs
@@ -117,6 +117,32 @@ pub struct UpdateZonesRequest {
     #[prost(message, repeated, tag = "1")]
     pub zones: ::prost::alloc::vec::Vec<Zone>,
 }
+/// Update flight paths
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateFlightPathRequest {
+    /// The unique identifier for the flight
+    #[prost(string, optional, tag = "1")]
+    pub flight_identifier: ::core::option::Option<::prost::alloc::string::String>,
+    /// The unique identifier for the aircraft
+    #[prost(string, optional, tag = "2")]
+    pub aircraft_identifier: ::core::option::Option<::prost::alloc::string::String>,
+    /// If this is a simulated flight
+    #[prost(bool, tag = "3")]
+    pub simulated: bool,
+    /// The type of aircraft
+    #[prost(enumeration = "crate::prelude::AircraftType", tag = "4")]
+    pub aircraft_type: i32,
+    /// The path of the aircraft
+    #[prost(message, repeated, tag = "5")]
+    pub path: ::prost::alloc::vec::Vec<PointZ>,
+    /// The planned start time of the flight
+    #[prost(message, optional, tag = "6")]
+    pub timestamp_start: ::core::option::Option<::lib_common::time::Timestamp>,
+    /// The planned end time of the flight
+    #[prost(message, optional, tag = "7")]
+    pub timestamp_end: ::core::option::Option<::lib_common::time::Timestamp>,
+}
 /// Best Path Request object
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -512,6 +538,28 @@ pub mod rpc_service_client {
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("grpc.RpcService", "updateZones"));
+            self.inner.unary(req, path, codec).await
+        }
+        pub async fn update_flight_path(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UpdateFlightPathRequest>,
+        ) -> std::result::Result<tonic::Response<super::UpdateResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/grpc.RpcService/updateFlightPath",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(GrpcMethod::new("grpc.RpcService", "updateFlightPath"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn best_path(

--- a/client-grpc/src/service.rs
+++ b/client-grpc/src/service.rs
@@ -121,6 +121,42 @@ where
         request: super::UpdateZonesRequest,
     ) -> Result<tonic::Response<super::UpdateResponse>, tonic::Status>;
 
+    /// Returns a [`tonic::Response`] containing a [`UpdateResponse`](super::UpdateResponse)
+    /// Takes an [`UpdateFlightPathRequest`](super::UpdateFlightPathRequest).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tonic::Status`] with [`Code::Unknown`](tonic::Code::Unknown) if
+    /// the server is not ready.
+    ///
+    /// # Examples
+    /// ```
+    /// use lib_common::grpc::get_endpoint_from_env;
+    /// use svc_gis_client_grpc::prelude::*;
+    /// use chrono::Utc;
+    ///
+    /// async fn example () -> Result<(), Box<dyn std::error::Error>> {
+    ///     let (host, port) = get_endpoint_from_env("SERVER_HOSTNAME", "SERVER_PORT_GRPC");
+    ///     let client = GisClient::new_client(&host, port, "gis");
+    ///     let request = gis::UpdateFlightPathRequest {
+    ///         flight_identifier: Some("flight-x".to_string()),
+    ///         aircraft_identifier: Some("aircraft-x".to_string()),
+    ///         simulated: false,
+    ///         aircraft_type: AircraftType::Rotorcraft as i32,
+    ///         timestamp_start: Some(Utc::now().into()),
+    ///         timestamp_end: Some(Utc::now().into()),
+    ///         path: vec![],
+    ///     };
+    ///     let response = client.update_flight_path(request).await?;
+    ///     println!("RESPONSE={:?}", response.into_inner());
+    ///     Ok(())
+    /// }
+    /// ```
+    async fn update_flight_path(
+        &self,
+        request: super::UpdateFlightPathRequest,
+    ) -> Result<tonic::Response<super::UpdateResponse>, tonic::Status>;
+
     /// Returns a [`tonic::Response`] containing a [`BestPathResponse`](super::BestPathResponse)
     /// Takes an [`BestPathRequest`](super::BestPathRequest).
     ///

--- a/common/types.rs
+++ b/common/types.rs
@@ -10,9 +10,6 @@ pub const REDIS_KEY_AIRCRAFT_POSITION: &str = "gis:aircraft:position";
 /// The key for the Redis queue containing aircraft velocity information
 pub const REDIS_KEY_AIRCRAFT_VELOCITY: &str = "gis:aircraft:velocity";
 
-/// The key for the Redis queue containing flight path information
-pub const REDIS_KEY_FLIGHT_PATH: &str = "gis:flight";
-
 /// Aircraft Type
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 #[derive(strum::EnumString)]
@@ -180,29 +177,4 @@ pub struct AircraftVelocity {
     pub timestamp_asset: Option<DateTime<Utc>>
 
     // TODO(R5): velocity uncertainty
-}
-
-/// A flight path is a series of positions and times that an aircraft will follow
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct FlightPath {
-    /// The unique identifier for the flight
-    pub flight_identifier: String,
-
-    /// The unique identifier for the aircraft
-    pub aircraft_identifier: String,
-
-    /// If this is a simulated flight
-    pub simulated: bool,
-
-    /// The type of aircraft
-    pub aircraft_type: AircraftType,
-
-    /// The path of the aircraft
-    pub path: Vec<Position>,
-
-    /// The planned start time of the flight
-    pub timestamp_start: DateTime<Utc>,
-
-    /// The planned end time of the flight
-    pub timestamp_end: DateTime<Utc>,
 }

--- a/proto/grpc.proto
+++ b/proto/grpc.proto
@@ -7,9 +7,9 @@ service RpcService {
     rpc updateVertiports(updateVertiportsRequest) returns (UpdateResponse);
     rpc updateWaypoints(updateWaypointsRequest) returns (UpdateResponse);
     rpc updateZones(UpdateZonesRequest) returns (UpdateResponse);
+    rpc updateFlightPath(UpdateFlightPathRequest) returns (UpdateResponse);
     rpc bestPath(BestPathRequest) returns (BestPathResponse);
     rpc getFlights(GetFlightsRequest) returns (GetFlightsResponse);
-    // rpc nearestNeighbors(NearestNeighborRequest) returns (NearestNeighborResponse);
 }
 
 // The nodes involved in the best path request
@@ -127,6 +127,30 @@ message Zone {
 message UpdateZonesRequest {
     // Nodes to update
     repeated Zone zones = 1;
+}
+
+// Update flight paths
+message UpdateFlightPathRequest {
+    // The unique identifier for the flight
+    optional string flight_identifier = 1;
+
+    // The unique identifier for the aircraft
+    optional string aircraft_identifier = 2;
+
+    // If this is a simulated flight
+    bool simulated = 3;
+
+    // The type of aircraft
+    AircraftType aircraft_type = 4;
+
+    // The path of the aircraft
+    repeated PointZ path = 5;
+
+    // The planned start time of the flight
+    google.protobuf.Timestamp timestamp_start = 6;
+
+    // The planned end time of the flight
+    google.protobuf.Timestamp timestamp_end = 7;
 }
 
 // Best Path Request object

--- a/server/src/grpc/server.rs
+++ b/server/src/grpc/server.rs
@@ -85,6 +85,23 @@ impl RpcService for ServerImpl {
     }
 
     #[cfg(not(tarpaulin_include))]
+    async fn update_flight_path(
+        &self,
+        request: Request<grpc_server::UpdateFlightPathRequest>,
+    ) -> Result<Response<grpc_server::UpdateResponse>, Status> {
+        grpc_debug!("(update_flight_path) entry.");
+
+        // Update nodes in PostGIS
+        match flight::update_flight_path(request.into_inner()).await {
+            Ok(_) => Ok(Response::new(grpc_server::UpdateResponse { updated: true })),
+            Err(e) => {
+                grpc_error!("(update_flight_path) error updating flight path: {}", e);
+                Err(Status::internal(e.to_string()))
+            }
+        }
+    }
+
+    #[cfg(not(tarpaulin_include))]
     async fn best_path(
         &self,
         request: Request<grpc_server::BestPathRequest>,
@@ -237,6 +254,16 @@ impl RpcService for ServerImpl {
         _request: Request<grpc_server::UpdateZonesRequest>,
     ) -> Result<Response<grpc_server::UpdateResponse>, Status> {
         grpc_warn!("(update_zones MOCK) entry.");
+
+        Ok(Response::new(grpc_server::UpdateResponse { updated: true }))
+    }
+
+    #[cfg(not(tarpaulin_include))]
+    async fn update_flight_path(
+        &self,
+        request: Request<grpc_server::UpdateFlightPathRequest>,
+    ) -> Result<Response<grpc_server::UpdateResponse>, Status> {
+        grpc_debug!("(update_flight_path MOCK) entry.");
 
         Ok(Response::new(grpc_server::UpdateResponse { updated: true }))
     }

--- a/server/src/grpc/server.rs
+++ b/server/src/grpc/server.rs
@@ -261,7 +261,7 @@ impl RpcService for ServerImpl {
     #[cfg(not(tarpaulin_include))]
     async fn update_flight_path(
         &self,
-        request: Request<grpc_server::UpdateFlightPathRequest>,
+        _request: Request<grpc_server::UpdateFlightPathRequest>,
     ) -> Result<Response<grpc_server::UpdateResponse>, Status> {
         grpc_debug!("(update_flight_path MOCK) entry.");
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,8 +1,8 @@
 //! Main function starting the server and initializing dependencies.
 
 use crate::types::{
-    AircraftId, AircraftPosition, AircraftVelocity, FlightPath, REDIS_KEY_AIRCRAFT_ID,
-    REDIS_KEY_AIRCRAFT_POSITION, REDIS_KEY_AIRCRAFT_VELOCITY, REDIS_KEY_FLIGHT_PATH,
+    AircraftId, AircraftPosition, AircraftVelocity, REDIS_KEY_AIRCRAFT_ID,
+    REDIS_KEY_AIRCRAFT_POSITION, REDIS_KEY_AIRCRAFT_VELOCITY,
 };
 use cache::Consumer;
 use log::info;
@@ -16,7 +16,6 @@ async fn start_redis_consumers(config: &Config) -> Result<(), ()> {
     let mut id_consumer = Consumer::new(config, REDIS_KEY_AIRCRAFT_ID, 500).await?;
     let mut position_consumer = Consumer::new(config, REDIS_KEY_AIRCRAFT_POSITION, 100).await?;
     let mut velocity_consumer = Consumer::new(config, REDIS_KEY_AIRCRAFT_VELOCITY, 100).await?;
-    let mut flight_consumer = Consumer::new(config, REDIS_KEY_FLIGHT_PATH, 500).await?;
 
     tokio::spawn(
         async move { <Consumer as IsConsumer<AircraftId>>::begin(&mut id_consumer).await },
@@ -29,10 +28,6 @@ async fn start_redis_consumers(config: &Config) -> Result<(), ()> {
     tokio::spawn(async move {
         <Consumer as IsConsumer<AircraftVelocity>>::begin(&mut velocity_consumer).await
     });
-
-    tokio::spawn(
-        async move { <Consumer as IsConsumer<FlightPath>>::begin(&mut flight_consumer).await },
-    );
 
     Ok(())
 }

--- a/server/src/postgis/best_path.rs
+++ b/server/src/postgis/best_path.rs
@@ -452,7 +452,7 @@ async fn mod_a_star(
     let start_time = Utc::now();
     while completed.len() < limit && !potentials.is_empty() {
         if Utc::now() - start_time > time_limit {
-            postgis_debug!("(mod_a_star) max calculation time reached");
+            postgis_warn!("(mod_a_star) max calculation time reached");
             return Err(PostgisError::BestPath(PathError::NoPath));
         }
 

--- a/server/src/postgis/mod.rs
+++ b/server/src/postgis/mod.rs
@@ -23,7 +23,7 @@ pub static DEADPOOL_POSTGIS: OnceCell<deadpool_postgres::Pool> = OnceCell::new()
 pub const PSQL_SCHEMA: &str = "arrow";
 
 /// Default Spatial Reference Identifier
-/// WGS84 with Z axis: https://spatialreference.org/ref/epsg/4326/
+/// WGS84 with Z axis: <https://spatialreference.org/ref/epsg/4326/>
 pub const DEFAULT_SRID: i32 = 4326;
 
 /// Error type for postgis actions

--- a/server/src/postgis/utils.rs
+++ b/server/src/postgis/utils.rs
@@ -2,7 +2,7 @@
 
 use super::DEFAULT_SRID;
 use super::{PostgisError, PsqlError};
-use crate::grpc::server::grpc_server::Coordinates;
+use crate::grpc::server::grpc_server::{Coordinates, PointZ as GrpcPointZ};
 use crate::types::Position;
 use chrono::{DateTime, Duration, Utc};
 use deadpool_postgres::tokio_postgres::{types::ToSql, Row};
@@ -125,6 +125,19 @@ impl TryFrom<Position> for PointZ {
             position.longitude,
             position.latitude,
             position.altitude_meters,
+            Some(DEFAULT_SRID),
+        ))
+    }
+}
+
+impl TryFrom<GrpcPointZ> for PointZ {
+    type Error = ();
+
+    fn try_from(position: GrpcPointZ) -> Result<Self, Self::Error> {
+        Ok(PointZ::new(
+            position.longitude,
+            position.latitude,
+            position.altitude_meters as f64,
             Some(DEFAULT_SRID),
         ))
     }

--- a/server/src/postgis/utils.rs
+++ b/server/src/postgis/utils.rs
@@ -261,11 +261,8 @@ pub async fn segmentize(
     points: Vec<PointZ>,
     timestamp_start: DateTime<Utc>,
     timestamp_end: DateTime<Utc>,
+    max_segment_len_meters: f32,
 ) -> Result<Vec<Segment>, PostgisError> {
-    // TODO(R5): Configurable
-    /// The maximum length of a flight segment in meters
-    const MAX_SEGMENT_LENGTH_M: f64 = 40.0;
-
     let geom = LineStringT {
         points,
         srid: Some(DEFAULT_SRID),
@@ -305,7 +302,7 @@ pub async fn segmentize(
     })?;
 
     let mut results = client
-        .query(&stmt, &[&geom, &MAX_SEGMENT_LENGTH_M])
+        .query(&stmt, &[&geom, &(max_segment_len_meters as f64)])
         .await
         .map_err(|e| {
             postgis_error!("(segmentize) could not execute query: {}", e);
@@ -355,11 +352,11 @@ pub async fn segmentize(
             PostgisError::Psql(PsqlError::Execute)
         })?;
 
-    postgis_debug!(
-        "(segmentize) found {} segments. craft velocity {} m/s.",
-        results.len(),
-        velocity_m_s
-    );
+    // postgis_debug!(
+    //     "(segmentize) found {} segments. craft velocity {} m/s.",
+    //     results.len(),
+    //     velocity_m_s
+    // );
 
     Ok(results)
 }

--- a/server/src/postgis/zone.rs
+++ b/server/src/postgis/zone.rs
@@ -293,15 +293,16 @@ pub async fn get_zone_intersection_stmt(
                 "time_end"
             FROM {table_name}
             WHERE
-                ("time_start" <= $3 OR "time_start" IS NULL)
+                ST_3DIntersects("geom", $1::GEOMETRY(LINESTRINGZ, {DEFAULT_SRID}))
+                AND ("time_start" <= $3 OR "time_start" IS NULL)
                 AND ("time_end" >= $2 OR "time_end" IS NULL)
                 AND "identifier" NOT IN ($4, $5)
-                AND ST_3DIntersects("geom", $1::GEOMETRY(LINESTRINGZ, {DEFAULT_SRID}))
             LIMIT 1;
         "#,
             table_name = get_table_name()
         ))
         .await;
+
     match result {
         Ok(stmt) => Ok(stmt),
         Err(e) => {


### PR DESCRIPTION
as discussed, svc-scheduler will be calling this interface as part of reserving a flight path.
- If svc-gis dies for whatever reason, it's ok if this fails because scheduler will simply not go through with the flight booking.

## Fixes Summary

For the shortest path algorithm, we recently implemented path segmentation. We break path potentials into 40m chunks, then checked each chunk against no-fly and pre-existing flight plans. This allowed us better flight intersection resolution than comparing whole flight paths. This worked well with small distances (small number of chunks) but struggled with large distances (20km into 40m chunks is a lot of chunks, each compared against all flight plan chunks...).

The fix added to this PR is to segmentize only if we need to. We check the whole path, and if there's any intersection we will make a note that it needs to be segmentized further and push it back in the potentials list.

The shortest path heuristic (a path "score", where smaller is better) is now multiplied by its "segment_factor". When an intersection occurs, we bump the segment factor for the path and push it back in the potentials list. The higher segment factor increases the heuristic score for that path, deprioritizing it. We allow this up to a limit (if path chunks get any smaller than 40m, then don't try again).

This might have the downside however of choosing longer routes that have no conflicts at any point vs. routes that have a path conflict at some point (but not necessarily an aircraft proximity conflict). Will solve later

Also bumped the waypoint range (how far away to look for waypoints), as it was 1 km before (fine for the small demo) but needed to be much larger for a Noord-Holland demo

Also added a 10 second limit/bailout on the shortest path algorithm in case of a runaway calculation or bug, which can tie up the system