### PR TITLE
R5 Optimization Features

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -108,3 +108,5 @@ isas
 AETH
 Rnever
 amsmith
+vertipad
+multipoint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -127,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "approx"
@@ -191,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -266,17 +260,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -332,9 +326,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cargo-husky"
@@ -344,9 +338,9 @@ checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cc"
-version = "1.1.15"
+version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
  "shlex",
 ]
@@ -396,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.16"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -406,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.15"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -418,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -475,18 +469,18 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -511,9 +505,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -696,7 +690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -885,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
@@ -1060,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1199,9 +1193,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libm"
@@ -1308,15 +1302,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -1601,9 +1586,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.11"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1612,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.11"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1622,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.11"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1635,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.11"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
 dependencies = [
  "once_cell",
  "pest",
@@ -1726,9 +1711,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "postgis"
@@ -1743,11 +1728,11 @@ dependencies = [
 
 [[package]]
 name = "postgres-derive"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83145eba741b050ef981a9a1838c843fa7665e154383325aa8b440ae703180a2"
+checksum = "69700ea4603c5ef32d447708e6a19cd3e8ac197a000842e97f527daea5e4175f"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -1786,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
+checksum = "f66ea23a2d0e5734297357705193335e0a957696f34bed2f2faefacb2fec336f"
 dependencies = [
  "bytes",
  "chrono",
@@ -2034,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2125,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.35"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d50532239da68e9addb745ba38ff4612a242c1c7ceea689c4bc7c2f43c36f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2150,11 +2135,11 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2178,9 +2163,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2194,9 +2179,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -2213,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2224,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.127"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
  "memchr",
@@ -2246,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -2353,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd14cf9e23b5241e1b1289ed3b9afc7746c95ead8df52d9254f5ed2d40c561b"
+checksum = "93f5ef1f863aca7d1d7dda7ccfc36a0a4279bd6d3c375176e5e0712e25cb4889"
 dependencies = [
  "hashbrown 0.14.5",
  "num-traits",
@@ -2548,18 +2533,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2642,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03adcf0147e203b6032c0b2d30be1415ba03bc348901f3ff1cc0df6a733e60c3"
+checksum = "3b5d3742945bc7d7f210693b0c58ae542c6fd47b17adbbda0885f3dcb34a6bdb"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2668,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2679,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2722,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.5.0",
  "serde",
@@ -2939,15 +2924,15 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -2960,9 +2945,9 @@ checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-any-ors"
@@ -3264,9 +3249,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/client-grpc/examples/grpc.rs
+++ b/client-grpc/examples/grpc.rs
@@ -17,6 +17,20 @@ async fn add_vertiports(client: &GisClient) -> Result<(), Box<dyn std::error::Er
         Vertiport {
             identifier: VERTIPORT_1_ID.to_string(),
             altitude_meters: 10.0,
+            ingresses: vec![Guide {
+                path: vec![PointZ {
+                    latitude: 52.37459497984641,
+                    longitude: 4.916006752910129,
+                    altitude_meters: 30.0,
+                }],
+            }],
+            egresses: vec![Guide {
+                path: vec![PointZ {
+                    latitude: 52.37475919958936,
+                    longitude: 4.916218239796025,
+                    altitude_meters: 30.0,
+                }],
+            }],
             vertices: vec![
                 (52.3746368, 4.9163718),
                 (52.3747387, 4.9162102),
@@ -36,6 +50,20 @@ async fn add_vertiports(client: &GisClient) -> Result<(), Box<dyn std::error::Er
         Vertiport {
             identifier: VERTIPORT_2_ID.to_string(),
             altitude_meters: 10.0,
+            ingresses: vec![Guide {
+                path: vec![PointZ {
+                    latitude: 52.37515645957456,
+                    longitude: 4.916025515664524,
+                    altitude_meters: 30.0,
+                }],
+            }],
+            egresses: vec![Guide {
+                path: vec![PointZ {
+                    latitude: 52.37553535490327,
+                    longitude: 4.916379172323348,
+                    altitude_meters: 30.0,
+                }],
+            }],
             vertices: vec![
                 (52.3751407, 4.916294),
                 (52.3752201, 4.9162611),
@@ -56,6 +84,20 @@ async fn add_vertiports(client: &GisClient) -> Result<(), Box<dyn std::error::Er
         Vertiport {
             identifier: VERTIPORT_3_ID.to_string(),
             altitude_meters: 10.0,
+            ingresses: vec![Guide {
+                path: vec![PointZ {
+                    latitude: 52.375353598244196,
+                    longitude: 4.915376026175216,
+                    altitude_meters: 30.0,
+                }],
+            }],
+            egresses: vec![Guide {
+                path: vec![PointZ {
+                    latitude: 52.37556974122148,
+                    longitude: 4.91592856118993,
+                    altitude_meters: 30.0,
+                }],
+            }],
             vertices: vec![
                 (52.3753536, 4.9157569),
                 (52.3752766, 4.9157193),
@@ -272,6 +314,20 @@ async fn best_path_flight_avoidance(
     let alkmaar_1 = Vertiport {
         identifier: ALKMAAR_1_ID.to_string(),
         altitude_meters: DEFAULT_ALTITUDE as f32,
+        ingresses: vec![Guide {
+            path: vec![PointZ {
+                longitude: 4.713354790437145,
+                altitude_meters: 30.0,
+                latitude: 52.630313405112695,
+            }],
+        }],
+        egresses: vec![Guide {
+            path: vec![PointZ {
+                longitude: 4.714234554926594,
+                altitude_meters: 30.0,
+                latitude: 52.631101340997176,
+            }],
+        }],
         vertices,
         label: Some("Alkmaar 1".to_string()),
         timestamp_network: Some(Utc::now().into()),
@@ -299,6 +355,20 @@ async fn best_path_flight_avoidance(
         identifier: ALKMAAR_2_ID.to_string(),
         altitude_meters: DEFAULT_ALTITUDE as f32,
         vertices,
+        ingresses: vec![Guide {
+            path: vec![PointZ {
+                longitude: 4.717608692851589,
+                altitude_meters: 30.0,
+                latitude: 52.63397113547141,
+            }],
+        }],
+        egresses: vec![Guide {
+            path: vec![PointZ {
+                longitude: 4.718885424244811,
+                altitude_meters: 30.0,
+                latitude: 52.633489290616936,
+            }],
+        }],
         label: Some("Alkmaar 2".to_string()),
         timestamp_network: Some(Utc::now().into()),
     };
@@ -506,6 +576,7 @@ async fn get_flights(client: &GisClient) -> Result<(), Box<dyn std::error::Error
 
 async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>> {
     // Best Path Without No-Fly Zone
+    let time_start = Utc::now();
     {
         println!("\n\u{1F426} Best Path WITHOUT Temporary No-Fly Zone");
         let time_start: Timestamp = Utc::now().into();
@@ -525,6 +596,10 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
         println!("RESPONSE={:?}", response);
         display_paths(&response.paths);
     }
+    println!(
+        "Time taken: {:?}",
+        (Utc::now() - time_start).num_milliseconds()
+    );
 
     let no_fly_start_time = Utc::now();
     let no_fly_end_time = Utc::now() + Duration::try_hours(2).unwrap();
@@ -605,6 +680,7 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
 
     // Best Path During Temporary No-Fly Zone
     {
+        let current = Utc::now();
         println!("\n\u{26D4}\u{1F681} Best Path DURING Temporary No-Fly Zone");
         let time_start: Timestamp = no_fly_start_time.into();
         let time_end: Timestamp = (no_fly_start_time + Duration::try_hours(1).unwrap()).into();
@@ -618,20 +694,20 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
             limit: 1,
         };
 
-        let mut response = client.best_path(request).await?.into_inner();
+        let response = client.best_path(request).await?.into_inner();
 
         println!("RESPONSE={:?}", response);
         display_paths(&response.paths);
-
-        let expected = 3;
-        if response.paths.pop().unwrap().path.len() != expected {
-            panic!("Expected {expected} paths, got {}", response.paths.len());
-        }
+        println!(
+            "Time taken: {:?}",
+            (Utc::now() - current).num_milliseconds()
+        );
     }
 
     // Best Path After Temporary No-Fly Zone
     {
         println!("\n\u{1F681} Best Path AFTER Temporary No-Fly Zone Expires");
+        let current = Utc::now();
         let time_start: Timestamp = (no_fly_end_time + Duration::try_seconds(1).unwrap()).into();
         let time_end: Timestamp = (no_fly_end_time + Duration::try_hours(1).unwrap()).into();
         let request = BestPathRequest {
@@ -648,11 +724,16 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
 
         println!("RESPONSE={:?}", response);
         display_paths(&response.paths);
+        println!(
+            "Time taken: {:?}",
+            (Utc::now() - current).num_milliseconds()
+        );
     }
 
     // Best Path From Aircraft
     {
         println!("\n\u{1F681} Best Path From Aircraft during TFR");
+        let current = Utc::now();
         let time_start: Timestamp = no_fly_start_time.into();
         let time_end: Timestamp = (no_fly_start_time + Duration::try_hours(1).unwrap()).into();
         let request = BestPathRequest {
@@ -669,6 +750,10 @@ async fn best_paths(client: &GisClient) -> Result<(), Box<dyn std::error::Error>
 
         println!("RESPONSE={:?}", response);
         display_paths(&response.paths);
+        println!(
+            "Time taken: {:?}",
+            (Utc::now() - current).num_milliseconds()
+        );
     }
 
     Ok(())
@@ -717,9 +802,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::thread::sleep(std::time::Duration::from_secs(1));
     get_flights(&client).await?;
     add_vertiports(&client).await?;
-    add_waypoints(&client).await?;
     best_paths(&client).await?;
     best_path_flight_avoidance(&mut connection, &client).await?;
+    add_waypoints(&client).await?;
 
     Ok(())
 }

--- a/client-grpc/src/grpc.rs
+++ b/client-grpc/src/grpc.rs
@@ -36,6 +36,14 @@ pub struct Coordinates {
     #[prost(double, tag = "2")]
     pub longitude: f64,
 }
+/// A path into or out of a vertiport
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Guide {
+    /// Path into or out of a vertiport
+    #[prost(message, repeated, tag = "1")]
+    pub path: ::prost::alloc::vec::Vec<PointZ>,
+}
 /// Vertiport Type
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -49,11 +57,17 @@ pub struct Vertiport {
     /// Altitude of this vertiport
     #[prost(float, tag = "3")]
     pub altitude_meters: f32,
+    /// Ingress waypoints for this vertiport
+    #[prost(message, repeated, tag = "4")]
+    pub ingresses: ::prost::alloc::vec::Vec<Guide>,
+    /// Egress waypoints for this vertiport
+    #[prost(message, repeated, tag = "5")]
+    pub egresses: ::prost::alloc::vec::Vec<Guide>,
     /// Vertiport label
-    #[prost(string, optional, tag = "4")]
+    #[prost(string, optional, tag = "6")]
     pub label: ::core::option::Option<::prost::alloc::string::String>,
     /// Network Timestamp
-    #[prost(message, optional, tag = "5")]
+    #[prost(message, optional, tag = "7")]
     pub timestamp_network: ::core::option::Option<::lib_common::time::Timestamp>,
 }
 /// Waypoint Type

--- a/client-grpc/tests/integration_test.rs
+++ b/client-grpc/tests/integration_test.rs
@@ -92,6 +92,8 @@ async fn test_add_vertiport() -> Result<(), Box<dyn std::error::Error>> {
         Vertiport {
             identifier: VERTIPORT_1_ID.to_string(),
             altitude_meters: 50.0,
+            ingresses: vec![],
+            egresses: vec![],
             label: Some("Bespin".to_string()),
             vertices: vec![
                 (52.3746368, 4.9163718),
@@ -111,6 +113,8 @@ async fn test_add_vertiport() -> Result<(), Box<dyn std::error::Error>> {
         Vertiport {
             identifier: VERTIPORT_2_ID.to_string(),
             altitude_meters: 50.0,
+            ingresses: vec![],
+            egresses: vec![],
             label: Some("Coruscant".to_string()),
             vertices: vec![
                 (52.3751407, 4.916294),
@@ -131,6 +135,8 @@ async fn test_add_vertiport() -> Result<(), Box<dyn std::error::Error>> {
         Vertiport {
             identifier: VERTIPORT_3_ID.to_string(),
             altitude_meters: 50.0,
+            ingresses: vec![],
+            egresses: vec![],
             label: Some("Kamino".to_string()),
             vertices: vec![
                 (52.3753536, 4.9157569),

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -47,11 +47,6 @@ services:
         target: /.env
 
   example:
-    links:
-      - web-server
-    depends_on:
-      web-server:
-        condition: service_healthy
     container_name: ${DOCKER_NAME}-example
     image: ${RUST_IMAGE_NAME}:${RUST_IMAGE_TAG}
     volumes:
@@ -71,11 +66,6 @@ services:
   it-coverage: &it-coverage
     <<: *coverage
     container_name: ${DOCKER_NAME}-it-coverage
-    links:
-      - web-server
-    depends_on:
-      web-server:
-        condition: service_healthy
     command: cargo tarpaulin --manifest-path "${CARGO_MANIFEST_PATH}" --workspace -l --test integration_test --features ${PACKAGE_IT_FEATURES} -v -t 600 --out Lcov --output-dir coverage/
 
   ut-coverage: &ut-coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,9 @@ services:
       - LOG_CONFIG
 
   example:
+    depends_on:
+      web-server:
+        condition: service_healthy
     extends:
       file: docker-compose-base.yml
       service: example
@@ -133,8 +136,9 @@ services:
     extends:
       file: docker-compose-base.yml
       service: it-coverage
-    links:
-      - postgis
+    depends_on:
+      web-server:
+        condition: service_healthy
     volumes:
       - type: volume
         source: postgis-ssl

--- a/proto/grpc.proto
+++ b/proto/grpc.proto
@@ -51,6 +51,12 @@ message Coordinates {
     double longitude = 2;
 }
 
+// A path into or out of a vertiport
+message Guide {
+    // Path into or out of a vertiport
+    repeated PointZ path = 1;
+}
+
 // Vertiport Type
 message Vertiport {
     // Unique Arrow ID
@@ -62,11 +68,17 @@ message Vertiport {
     // Altitude of this vertiport
     float altitude_meters = 3;
 
+    // Ingress waypoints for this vertiport
+    repeated Guide ingresses = 4;
+
+    // Egress waypoints for this vertiport
+    repeated Guide egresses = 5;
+
     // Vertiport label
-    optional string label = 4;
+    optional string label = 6;
 
     // Network Timestamp
-    google.protobuf.Timestamp timestamp_network = 5;
+    google.protobuf.Timestamp timestamp_network = 7;
 }
 
 // Waypoint Type

--- a/proto/grpc.proto
+++ b/proto/grpc.proto
@@ -236,6 +236,12 @@ message Path {
 
     // Total distance of this path
     float distance_meters = 2;
+
+    // // Total distance from start to first waypoint
+    // float takeoff_distance = 3;
+
+    // // Total distance from last waypoint to end
+    // float landing_distance = 4;
 }
 
 // Best Path Response object

--- a/server/src/postgis/waypoint.rs
+++ b/server/src/postgis/waypoint.rs
@@ -41,7 +41,7 @@ impl Display for WaypointError {
 }
 
 /// Gets the name of this module's table
-fn get_table_name() -> &'static str {
+pub fn get_table_name() -> &'static str {
     static FULL_NAME: &str = const_format::formatcp!(r#""{PSQL_SCHEMA}"."waypoints""#,);
     FULL_NAME
 }
@@ -115,9 +115,14 @@ pub async fn psql_init() -> Result<(), PostgisError> {
         format!(
             r#"CREATE TABLE IF NOT EXISTS {table_name} (
             "identifier" VARCHAR(255) UNIQUE NOT NULL,
-            "geog" GEOGRAPHY NOT NULL
+            "geog" GEOGRAPHY NOT NULL,
+            "zone_id" INTEGER,
+            CONSTRAINT "fk_zone"
+                FOREIGN KEY ("zone_id")
+                REFERENCES {zones_table_name} ("id")
         );"#,
-            table_name = get_table_name()
+            table_name = get_table_name(),
+            zones_table_name = super::zone::get_table_name()
         ),
         format!(
             r#"CREATE INDEX IF NOT EXISTS "waypoints_geog_idx" ON {table_name} USING GIST ("geog");"#,

--- a/server/src/postgis/zone.rs
+++ b/server/src/postgis/zone.rs
@@ -192,8 +192,8 @@ pub async fn psql_init() -> Result<(), PostgisError> {
             BEGIN
                 DELETE FROM {waypoints_table} WHERE "zone_id" = NEW."id";
 
-                FOR pt in 
-                    SELECT (ST_DumpPoints(ST_Expand(ST_Envelope(ST_Force2D(NEW."geom")), {distance_degrees})))."geom"
+                FOR pt in
+                    SELECT (ST_DumpPoints(ST_Buffer(ST_PatchN(NEW."geom", 1), {distance_degrees}, 'join=mitre mitre_limit=5.0')))."geom"
                 LOOP
                     INSERT INTO {waypoints_table} (
                         "identifier",


### PR DESCRIPTION
Multiple Updates

#### Unnecessary Waypoints/Waypoints Uninformed by Zones
<details>
In R4 we used a hardcoded set of waypoints that are randomly located around NL and TX without any connection to existing zones.

There are several improvements we can make here:
1) Waypoints are used mainly to get around zones that lie in the path of our ideal (direct) flight between pads, so waypoint placement should be informed by the location of zones. With no zones, theoretically no waypoints needed.
2) A high number of unnecessary waypoints leads to increased calculation time for best path algorithms with no real benefit, so the set of waypoints should be reduced to only those strictly necessary to skirt a zone

To best accomplish the above goal, it stands to reason that all waypoints should be:
1) Located close to a zone
    - to minimize the detour from the direct point-to-point (ideal) path
    - to provide a quick exit point for aircraft suddenly caught in a new zone restriction/warning
2) Abundant enough to provide a complete path around the zone without intersecting it

A solution provided here:
- When a zone is created, a set of associated waypoints are created to circumvent that zone.
- The waypoints are decided by taking the geometry of the zone, expanding it outwards by ~20 meters, then collecting the vertices of the geometry.
- A waypoint won't be created if it is within ~20 meters of another existing waypoint not belonging to its own zone
    - This is to prevent waypoints being created so close to another that there is no appreciable difference between them, and therefore no real benefit to the extra best_path and intersection calculations
- When the zone is deleted, its waypoints are deleted with it. Waypoints therefore have the same lifespan as the zone.

![zone](https://github.com/user-attachments/assets/c6920340-2d04-475e-ab44-293d7ae9a883)
![image](https://github.com/user-attachments/assets/629598b0-6f0a-49bb-826d-f84fc08d5294)

This allows us to discard the random assortment of waypoints currently hardcoded, and instead provide a much reduced set of waypoints that are the absolute minimum needed to cirumvent a zone.
</details>

#### Best path now only returns waypoints, not the vertipad locations
<details>
In R4 svc-gis simply returned a single path from pad to pad, implicit that the first two points in the pad are the vertipad ground location and the first waypoint, respectively. Likewise the final two points in the path implicitly belonged to the final waypoint and the destination vertipad ground location.

With a MAVLINK .plan file, takeoff and GPS nav are separate steps. We want to be explicit about where the GPS nav steps begin and where takeoff/landing begins. Therefore "best_path" will now only return the waypoints involved in GPS nav and not the vertipad locations themselves. The first waypoint indicates the target for the takeoff command, and the final waypoint is where landing will occur from toward the known destination pad location.
</details>

#### Ingress & Egress Waypoints
<details>
To improve safety, we established a pair of waypoints that must be traversed before entering/exiting the vertiports' zone.

This is a step toward designing vertipad approaches where the drones' takeoff and landing paths ideally don't cross:
![image](https://github.com/user-attachments/assets/a8bf5385-67d8-46dc-b00b-79a2be4448f1)

The best path algorithm will start with the egress waypoint of vertipad A (this is where takeoff must occur to). It will navigate toward the ingress waypoint of vertiport B (rather than the vertiport itself, as was previously the case). From there the correct approach from and to the departure and destination pads can be prepended and appended, respectively.
</details>